### PR TITLE
Switch to using seamless-immutable

### DIFF
--- a/app/actions/resourceActions.js
+++ b/app/actions/resourceActions.js
@@ -35,7 +35,7 @@ function fetchResources() {
       endpoint: `${API_URL}/resource`,
       method: 'GET',
       bailout: (state) => {
-        return !state.search.getIn(['searchResults', 'shouldFetch']);
+        return !state.search.searchResults.shouldFetch;
       },
     },
   };

--- a/app/components/search-page/SearchResult.js
+++ b/app/components/search-page/SearchResult.js
@@ -1,5 +1,4 @@
-import React, { Component } from 'react';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 
 export class SearchResult extends Component {
@@ -9,18 +8,18 @@ export class SearchResult extends Component {
     return (
       <tr>
         <td>
-          <Link to={`/resources/${result.get('id')}`}>
-            {result.getIn(['name', 'fi'])}
+          <Link to={`/resources/${result.id}`}>
+            {result.name.fi}
           </Link>
         </td>
-        <td>{result.get('unit')}</td>
+        <td>{result.unit}</td>
       </tr>
     );
   }
 }
 
 SearchResult.propTypes = {
-  result: ImmutablePropTypes.map.isRequired,
+  result: PropTypes.object.isRequired,
 };
 
 export default SearchResult;

--- a/app/components/search-page/SearchResults.js
+++ b/app/components/search-page/SearchResults.js
@@ -1,13 +1,13 @@
+import _ from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { Table } from 'react-bootstrap';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import Loader from 'react-loader';
 
 import SearchResult from 'components/search-page/SearchResult';
 
 export class SearchResults extends Component {
   renderSearchResult(result) {
-    return <SearchResult key={result.get('id')} result={result} />;
+    return <SearchResult key={result.id} result={result} />;
   }
 
   render() {
@@ -23,7 +23,7 @@ export class SearchResults extends Component {
             </tr>
           </thead>
           <tbody>
-            {results.map(this.renderSearchResult)}
+            {_.map(results, this.renderSearchResult)}
           </tbody>
         </Table>
       </Loader>
@@ -33,7 +33,7 @@ export class SearchResults extends Component {
 
 SearchResults.propTypes = {
   isFetching: PropTypes.bool,
-  results: ImmutablePropTypes.list.isRequired,
+  results: PropTypes.array.isRequired,
 };
 
 export default SearchResults;

--- a/app/components/search-page/__tests__/SearchResult.spec.js
+++ b/app/components/search-page/__tests__/SearchResult.spec.js
@@ -2,14 +2,14 @@ import { expect } from 'chai';
 import React from 'react';
 import TestUtils from 'react/lib/ReactTestUtils';
 
-import { fromJS } from 'immutable';
+import Immutable from 'seamless-immutable';
 import { Link } from 'react-router';
 
 import SearchResult from 'components/search-page/SearchResult';
 
 function setup() {
   const props = {
-    result: fromJS({
+    result: Immutable({
       id: 'r-1',
       name: { fi: 'Some resource' },
       unit: 'u-1',

--- a/app/components/search-page/__tests__/SearchResults.spec.js
+++ b/app/components/search-page/__tests__/SearchResults.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import React from 'react';
 import TestUtils from 'react/lib/ReactTestUtils';
 
-import { fromJS } from 'immutable';
+import Immutable from 'seamless-immutable';
 import { Table } from 'react-bootstrap';
 
 import SearchResult from 'components/search-page/SearchResult';
@@ -11,9 +11,9 @@ import SearchResults from 'components/search-page/SearchResults';
 describe('Component: SearchResults', () => {
   let element;
   const props = {
-    results: fromJS([
-      { id: 'r-1' },
-      { id: 'r-2' },
+    results: Immutable([
+      { id: 'r-1', name: { fi: 'Some resource' } },
+      { id: 'r-2', name: { fi: 'Other resource' } },
     ]),
   };
 
@@ -60,7 +60,7 @@ describe('Component: SearchResults', () => {
     });
 
     it('should render a SearchResult for every result in props', () => {
-      expect(resultComponents).to.have.length(props.results.size);
+      expect(resultComponents).to.have.length(props.results.length);
     });
   });
 });

--- a/app/containers/ResourcePage.js
+++ b/app/containers/ResourcePage.js
@@ -1,6 +1,6 @@
+import _ from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import DocumentTitle from 'react-document-title';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import Loader from 'react-loader';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -16,10 +16,11 @@ export class UnconnectedResourcePage extends Component {
 
   render() {
     const { resource } = this.props;
-    const name = resource.getIn(['name', 'fi']);
+    const name = resource.name ? resource.name.fi : '';
+
     return (
       <DocumentTitle title={`${name} - Respa`}>
-        <Loader loaded={Boolean(resource.size)}>
+        <Loader loaded={!_.isEmpty(resource)}>
           <div>
             <h1>{name}</h1>
           </div>
@@ -32,7 +33,7 @@ export class UnconnectedResourcePage extends Component {
 UnconnectedResourcePage.propTypes = {
   actions: PropTypes.object.isRequired,
   id: PropTypes.string.isRequired,
-  resource: ImmutablePropTypes.map.isRequired,
+  resource: PropTypes.object.isRequired,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/app/containers/SearchPage.js
+++ b/app/containers/SearchPage.js
@@ -1,6 +1,5 @@
 import React, { Component, PropTypes } from 'react';
 import DocumentTitle from 'react-document-title';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -36,7 +35,7 @@ UnconnectedSearchPage.propTypes = {
   category: PropTypes.string.isRequired,
   fetchResources: PropTypes.func.isRequired,
   isFetchingSearchResults: PropTypes.bool,
-  results: ImmutablePropTypes.list.isRequired,
+  results: PropTypes.array.isRequired,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/app/containers/__tests__/ResourcePage.spec.js
+++ b/app/containers/__tests__/ResourcePage.spec.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { findDOMNode } from 'react-dom';
 import TestUtils from 'react/lib/ReactTestUtils';
 
-import { fromJS } from 'immutable';
+import Immutable from 'seamless-immutable';
 
 import { UnconnectedResourcePage as ResourcePage } from 'containers/ResourcePage';
 
@@ -16,7 +16,7 @@ describe('Container: ResourcePage', () => {
   const props = {
     actions: { fetchResource: fetchResourceMock },
     id: 'r-1',
-    resource: fromJS({
+    resource: Immutable({
       name: {
         fi: name,
       },
@@ -40,6 +40,7 @@ describe('Container: ResourcePage', () => {
     it('should display resource name inside h1 tags', () => {
       const headerComponent = TestUtils.findRenderedDOMComponentWithTag(page, 'h1');
       const headerDOM = findDOMNode(headerComponent);
+
       expect(headerDOM.textContent).to.equal(name);
     });
   });

--- a/app/containers/__tests__/SearchPage.spec.js
+++ b/app/containers/__tests__/SearchPage.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import React from 'react';
 import TestUtils from 'react/lib/ReactTestUtils';
 
-import { List } from 'immutable';
+import Immutable from 'seamless-immutable';
 
 import SearchResults from 'components/search-page/SearchResults';
 import { UnconnectedSearchPage as SearchPage } from 'containers/SearchPage';
@@ -15,7 +15,7 @@ describe('Container: SearchPage', () => {
   const props = {
     category: 'Some category',
     fetchResources: fetchResourcesMock,
-    results: List(),
+    results: Immutable([]),
   };
   let page;
 
@@ -34,6 +34,7 @@ describe('Container: SearchPage', () => {
 
     it('should render SearchResults component', () => {
       const searchResults = TestUtils.findRenderedComponentWithType(page, SearchResults);
+
       expect(searchResults).to.exist;
     });
   });

--- a/app/reducers/__tests__/resources.spec.js
+++ b/app/reducers/__tests__/resources.spec.js
@@ -1,19 +1,16 @@
-import chai, { expect } from 'chai';
-import chaiImmutable from 'chai-immutable';
+import { expect } from 'chai';
 
-import { fromJS, Map } from 'immutable';
 import { createAction } from 'redux-actions';
+import Immutable from 'seamless-immutable';
 
 import * as types from 'constants/ActionTypes';
 import { resourcesReducer as reducer } from 'reducers/resources';
 
-chai.use(chaiImmutable);
-
 describe('Reducer: resourcesReducer', () => {
   describe('initial state', () => {
-    it('should be an empty Map', () => {
-      const expected = Map();
-      expect(reducer(undefined, {})).to.equal(expected);
+    it('should be an empty object', () => {
+      const initialState = reducer(undefined, {});
+      expect(initialState).to.deep.equal({});
     });
   });
 
@@ -33,30 +30,28 @@ describe('Reducer: resourcesReducer', () => {
       );
 
       it('should index the given resource by id and add it to state', () => {
-        const initialState = Map();
+        const initialState = Immutable({});
         const resource = { id: 'r-1', name: 'some resource' };
-        const expectedState = fromJS({
-          'r-1': { id: 'r-1', name: 'some resource' },
-        });
+        const expectedState = Immutable({ 'r-1': resource });
         const action = fetchResourceSuccess(resource);
 
-        expect(reducer(initialState, action)).to.equal(expectedState);
+        expect(reducer(initialState, action)).to.deep.equal(expectedState);
       });
 
       it('should not remove other resources from the state', () => {
-        const initialState = fromJS({
+        const initialState = Immutable({
           'r-1': { id: 'r-1', name: 'some resource' },
           'r-2': { id: 'r-2', name: 'other resource' },
         });
         const resource = { id: 'r-3', name: 'new resource' };
-        const expectedState = fromJS({
+        const expectedState = Immutable({
           'r-1': { id: 'r-1', name: 'some resource' },
           'r-2': { id: 'r-2', name: 'other resource' },
           'r-3': { id: 'r-3', name: 'new resource' },
         });
         const action = fetchResourceSuccess(resource);
 
-        expect(reducer(initialState, action)).to.equal(expectedState);
+        expect(reducer(initialState, action)).to.deep.equal(expectedState);
       });
 
       it('should overwrite previous resource with the same id', () => {
@@ -68,52 +63,30 @@ describe('Reducer: resourcesReducer', () => {
           id: 'r-1',
           name: 'some resource',
         };
-        const initialState = fromJS({ 'r-1': previousResource });
-        const expectedState = fromJS({ 'r-1': resource });
+        const initialState = Immutable({ 'r-1': previousResource });
+        const expectedState = Immutable({ 'r-1': resource });
         const action = fetchResourceSuccess(resource);
 
-        expect(reducer(initialState, action)).to.equal(expectedState);
+        expect(reducer(initialState, action)).to.deep.equal(expectedState);
       });
     });
 
     describe('FETCH_RESOURCES_SUCCESS', () => {
       const fetchResourcesSuccess = createAction(types.FETCH_RESOURCES_SUCCESS);
 
-      it('should return the state as Map', () => {
-        const resources = [
-          { id: 'r-1', name: 'some resource' },
-        ];
-        const initialState = Map();
-        const action = fetchResourcesSuccess(resources);
-        const state = reducer(initialState, action);
-
-        expect(Map.isMap(state)).to.be.true;
-      });
-
-      it('should save resources as Maps', () => {
-        const resources = [
-          { id: 'r-1', name: 'some resource' },
-        ];
-        const initialState = Map();
-        const action = fetchResourcesSuccess(resources);
-        const state = reducer(initialState, action);
-
-        expect(Map.isMap(state.get('r-1'))).to.be.true;
-      });
-
       it('should index the given resources by id and add them to state', () => {
         const resources = [
           { id: 'r-1', name: 'some resource' },
           { id: 'r-2', name: 'other resource' },
         ];
-        const initialState = Map();
-        const expectedState = Map({
-          'r-1': Map(resources[0]),
-          'r-2': Map(resources[1]),
+        const initialState = Immutable({});
+        const expectedState = Immutable({
+          'r-1': resources[0],
+          'r-2': resources[1],
         });
         const action = fetchResourcesSuccess(resources);
 
-        expect(reducer(initialState, action)).to.equal(expectedState);
+        expect(reducer(initialState, action)).to.deep.equal(expectedState);
       });
 
       it('should not remove previous resources from the state', () => {
@@ -122,17 +95,17 @@ describe('Reducer: resourcesReducer', () => {
           { id: 'r-2', name: 'other resource' },
         ];
         const previousResource = { id: 'r-3', name: 'previous resource' };
-        const initialState = Map({
-          'r-3': Map({ previousResource }),
+        const initialState = Immutable({
+          'r-3': previousResource,
         });
-        const expectedState = Map({
-          'r-1': Map(resources[0]),
-          'r-2': Map(resources[1]),
-          'r-3': Map({ previousResource }),
+        const expectedState = Immutable({
+          'r-1': resources[0],
+          'r-2': resources[1],
+          'r-3': previousResource,
         });
         const action = fetchResourcesSuccess(resources);
 
-        expect(reducer(initialState, action)).to.equal(expectedState);
+        expect(reducer(initialState, action)).to.deep.equal(expectedState);
       });
 
       it('should overwrite previous resources with the same id', () => {
@@ -141,16 +114,16 @@ describe('Reducer: resourcesReducer', () => {
           { id: 'r-2', name: 'other resource' },
         ];
         const previousResource = { id: 'r-1', name: 'old name' };
-        const initialState = Map({
-          'r-1': Map({ previousResource }),
+        const initialState = Immutable({
+          'r-1': previousResource,
         });
-        const expectedState = Map({
-          'r-1': Map(resources[0]),
-          'r-2': Map(resources[1]),
+        const expectedState = Immutable({
+          'r-1': resources[0],
+          'r-2': resources[1],
         });
         const action = fetchResourcesSuccess(resources);
 
-        expect(reducer(initialState, action)).to.equal(expectedState);
+        expect(reducer(initialState, action)).to.deep.equal(expectedState);
       });
     });
   });

--- a/app/reducers/__tests__/search.spec.js
+++ b/app/reducers/__tests__/search.spec.js
@@ -1,13 +1,10 @@
-import chai, { expect } from 'chai';
-import chaiImmutable from 'chai-immutable';
+import { expect } from 'chai';
 
-import { List, Map } from 'immutable';
 import { createAction } from 'redux-actions';
+import Immutable from 'seamless-immutable';
 
 import * as types from 'constants/ActionTypes';
 import { searchReducer as reducer } from 'reducers/search';
-
-chai.use(chaiImmutable);
 
 describe('Reducer: searchReducer', () => {
   describe('initial state', () => {
@@ -17,35 +14,31 @@ describe('Reducer: searchReducer', () => {
       initialState = reducer(undefined, {});
     });
 
-    it('should be a Map', () => {
-      expect(Map.isMap(initialState)).to.be.true;
-    });
-
     it('category should be "all"', () => {
-      expect(initialState.get('category')).to.equal('all');
+      expect(initialState.category).to.equal('all');
     });
 
     describe('searchResults', () => {
       let searchResults;
 
       before(() => {
-        searchResults = initialState.get('searchResults');
+        searchResults = initialState.searchResults;
       });
 
-      it('should be a Map', () => {
-        expect(Map.isMap(searchResults)).to.be.true;
+      it('should be an object', () => {
+        expect(typeof searchResults).to.equal('object');
       });
 
-      it('searchResults.ids as an empty List', () => {
-        expect(searchResults.get('ids')).to.equal(List());
+      it('searchResults.ids should be an empty array', () => {
+        expect(searchResults.ids).to.deep.equal([]);
       });
 
       it('searchResults.isFetching should be false', () => {
-        expect(searchResults.get('isFetching')).to.be.false;
+        expect(searchResults.isFetching).to.be.false;
       });
 
       it('searchResults.shouldFetch should be true', () => {
-        expect(searchResults.get('shouldFetch')).to.be.true;
+        expect(searchResults.shouldFetch).to.be.true;
       });
     });
   });
@@ -56,14 +49,15 @@ describe('Reducer: searchReducer', () => {
 
       it('should set searchResults.isFetching to true', () => {
         const action = fetchResourcesStart();
-        const initialState = Map({
-          searchResults: Map({
+        const initialState = Immutable({
+          searchResults: {
             isFetching: false,
-            ids: List(),
-          }),
+            ids: [],
+          },
         });
         const newState = reducer(initialState, action);
-        expect(newState.getIn(['searchResults', 'isFetching'])).to.be.true;
+
+        expect(newState.searchResults.isFetching).to.be.true;
       });
     });
 
@@ -76,53 +70,57 @@ describe('Reducer: searchReducer', () => {
 
       it('should set searchResults.isFetching to false', () => {
         const action = fetchResourcesSuccess(resources);
-        const initialState = Map({
-          searchResults: Map({
+        const initialState = Immutable({
+          searchResults: {
             isFetching: true,
-            ids: List(),
-          }),
+            ids: [],
+          },
         });
         const newState = reducer(initialState, action);
-        expect(newState.getIn(['searchResults', 'isFetching'])).to.be.false;
+
+        expect(newState.searchResults.isFetching).to.be.false;
       });
 
       it('should set searchResults.shouldFetch to false', () => {
         const action = fetchResourcesSuccess(resources);
-        const initialState = Map({
-          searchResults: Map({
-            ids: List(),
+        const initialState = Immutable({
+          searchResults: {
+            ids: [],
             isFetching: true,
             shouldFetch: true,
-          }),
+          },
         });
         const newState = reducer(initialState, action);
-        expect(newState.getIn(['searchResults', 'shouldFetch'])).to.be.false;
+
+        expect(newState.searchResults.shouldFetch).to.be.false;
       });
 
       it('should set the given resource ids to searchResults.ids', () => {
         const action = fetchResourcesSuccess(resources);
-        const initialState = Map({
-          searchResults: Map({
+        const initialState = Immutable({
+          searchResults: {
             isFetching: true,
-            ids: List(),
-          }),
+            ids: [],
+          },
         });
-        const expectedIds = List(['r-1', 'r-2']);
+        const expectedIds = ['r-1', 'r-2'];
         const newState = reducer(initialState, action);
-        expect(newState.getIn(['searchResults', 'ids'])).to.be.equal(expectedIds);
+
+        expect(newState.searchResults.ids).to.deep.equal(expectedIds);
       });
 
       it('should replace the old ids in searchResults.ids', () => {
         const action = fetchResourcesSuccess(resources);
-        const initialState = Map({
-          searchResults: Map({
+        const initialState = Immutable({
+          searchResults: {
             isFetching: true,
-            ids: List(['replace-this']),
-          }),
+            ids: ['replace-this'],
+          },
         });
-        const expectedIds = List(['r-1', 'r-2']);
+        const expectedIds = ['r-1', 'r-2'];
         const newState = reducer(initialState, action);
-        expect(newState.getIn(['searchResults', 'ids'])).to.be.equal(expectedIds);
+
+        expect(newState.searchResults.ids).to.deep.equal(expectedIds);
       });
     });
   });

--- a/app/reducers/__tests__/units.spec.js
+++ b/app/reducers/__tests__/units.spec.js
@@ -1,19 +1,16 @@
-import chai, { expect } from 'chai';
-import chaiImmutable from 'chai-immutable';
+import { expect } from 'chai';
 
-import { fromJS, Map } from 'immutable';
+import Immutable from 'seamless-immutable';
 import { createAction } from 'redux-actions';
 
 import * as types from 'constants/ActionTypes';
 import { unitsReducer as reducer } from 'reducers/units';
 
-chai.use(chaiImmutable);
-
 describe('Reducer: unitsReducer', () => {
   describe('initial state', () => {
-    it('should be an empty Map', () => {
-      const expected = Map();
-      expect(reducer(undefined, {})).to.equal(expected);
+    it('should be an empty object', () => {
+      const initialState = reducer(undefined, {});
+      expect(initialState).to.deep.equal({});
     });
   });
 
@@ -33,34 +30,34 @@ describe('Reducer: unitsReducer', () => {
       );
 
       it('should index the given unit by id and add it to state', () => {
-        const initialState = Map();
+        const initialState = Immutable({});
         const unit = { id: 'u-1', name: 'some unit' };
-        const expectedState = fromJS({
+        const expectedState = Immutable({
           'u-1': { id: 'u-1', name: 'some unit' },
         });
         const action = fetchResourceSuccess(unit);
 
-        expect(reducer(initialState, action)).to.equal(expectedState);
+        expect(reducer(initialState, action)).to.deep.equal(expectedState);
       });
 
       it('should not remove other units from the state', () => {
-        const initialState = fromJS({
+        const initialState = Immutable({
           'u-1': { id: 'u-1', name: 'some unit' },
           'u-2': { id: 'u-2', name: 'other unit' },
         });
         const unit = { id: 'u-3', name: 'new unit' };
-        const expectedState = fromJS({
+        const expectedState = Immutable({
           'u-1': { id: 'u-1', name: 'some unit' },
           'u-2': { id: 'u-2', name: 'other unit' },
           'u-3': { id: 'u-3', name: 'new unit' },
         });
         const action = fetchResourceSuccess(unit);
 
-        expect(reducer(initialState, action)).to.equal(expectedState);
+        expect(reducer(initialState, action)).to.deep.equal(expectedState);
       });
 
       it('should overwrite previous unit with the same id', () => {
-        const previousResource = {
+        const previousUnit = {
           id: 'u-1',
           name: 'old name',
         };
@@ -68,11 +65,11 @@ describe('Reducer: unitsReducer', () => {
           id: 'u-1',
           name: 'some unit',
         };
-        const initialState = fromJS({ 'u-1': previousResource });
-        const expectedState = fromJS({ 'u-1': unit });
+        const initialState = Immutable({ 'u-1': previousUnit });
+        const expectedState = Immutable({ 'u-1': unit });
         const action = fetchResourceSuccess(unit);
 
-        expect(reducer(initialState, action)).to.equal(expectedState);
+        expect(reducer(initialState, action)).to.deep.equal(expectedState);
       });
     });
   });

--- a/app/reducers/resources.js
+++ b/app/reducers/resources.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
-import { Map } from 'immutable';
+import Immutable from 'seamless-immutable';
 
 import ActionTypes from 'constants/ActionTypes';
 
-export function resourcesReducer(state = Map(), action) {
+export function resourcesReducer(state = Immutable({}), action) {
   let resources;
 
   switch (action.type) {

--- a/app/reducers/search.js
+++ b/app/reducers/search.js
@@ -1,27 +1,27 @@
 import _ from 'lodash';
-import { List, Map } from 'immutable';
+import Immutable from 'seamless-immutable';
 
 import ActionTypes from 'constants/ActionTypes';
 
-const initialState = Map({
+const initialState = Immutable({
   category: 'all',
-  searchResults: Map({
-    ids: List(),
+  searchResults: {
+    ids: [],
     isFetching: false,
     shouldFetch: true,
-  }),
+  },
 });
 
-function searchResults(state, action) {
+function searchResultsReducer(state, action) {
   switch (action.type) {
 
   case ActionTypes.FETCH_RESOURCES_START:
-    return state.set('isFetching', true);
+    return state.merge({ 'isFetching': true });
 
   case ActionTypes.FETCH_RESOURCES_SUCCESS:
     const resources = _.values(action.payload);
     return state.merge({
-      ids: List(_.pluck(resources, 'id')),
+      ids: _.pluck(resources, 'id'),
       isFetching: false,
       shouldFetch: false,
     });
@@ -36,7 +36,8 @@ export function searchReducer(state = initialState, action) {
 
   case ActionTypes.FETCH_RESOURCES_START:
   case ActionTypes.FETCH_RESOURCES_SUCCESS:
-    return state.set('searchResults', searchResults(state.get('searchResults'), action));
+    const searchResults = searchResultsReducer(state.searchResults, action);
+    return state.merge({ searchResults });
 
   default:
     return state;

--- a/app/reducers/units.js
+++ b/app/reducers/units.js
@@ -1,8 +1,8 @@
-import { Map } from 'immutable';
+import Immutable from 'seamless-immutable';
 
 import ActionTypes from 'constants/ActionTypes';
 
-export function unitsReducer(state = Map(), action) {
+export function unitsReducer(state = Immutable({}), action) {
   switch (action.type) {
 
   case ActionTypes.FETCH_RESOURCE_SUCCESS:

--- a/app/selectors/__tests__/resourcePageSelectors.spec.js
+++ b/app/selectors/__tests__/resourcePageSelectors.spec.js
@@ -1,11 +1,8 @@
-import chai, { expect } from 'chai';
-import chaiImmutable from 'chai-immutable';
+import { expect } from 'chai';
 
-import { fromJS, Map } from 'immutable';
+import Immutable from 'seamless-immutable';
 
 import { resourcePageSelectors } from 'selectors/resourcePageSelectors';
-
-chai.use(chaiImmutable);
 
 describe('Selectors: resourcePageSelectors', () => {
   let state;
@@ -17,7 +14,7 @@ describe('Selectors: resourcePageSelectors', () => {
           id: 'r-2',
         },
       },
-      resources: fromJS({
+      resources: Immutable({
         'r-1': { id: 'r-1', name: 'Some resource' },
         'r-2': { id: 'r-2', name: 'Other resource' },
       }),
@@ -28,20 +25,23 @@ describe('Selectors: resourcePageSelectors', () => {
     it('should return the id in router.params.id', () => {
       const selected = resourcePageSelectors(state);
       const expected = state.router.params.id;
+
       expect(selected.id).to.equal(expected);
     });
 
     it('should return the resource corresponding to the router.params.id', () => {
       const selected = resourcePageSelectors(state);
-      const expected = state.resources.get('r-2');
+      const resourceId = state.router.params.id;
+      const expected = state.resources[resourceId];
+
       expect(selected.resource).to.deep.equal(expected);
     });
 
-    it('should return empty Map as resource if resource with given id is not fetched', () => {
+    it('should return an empty object as resource if resource with given id is not fetched', () => {
       state.router.params.id = 'r-9999';
       const selected = resourcePageSelectors(state);
-      const expected = Map();
-      expect(selected.resource).to.deep.equal(expected);
+
+      expect(selected.resource).to.deep.equal({});
     });
   });
 });

--- a/app/selectors/__tests__/searchPageSelectors.spec.js
+++ b/app/selectors/__tests__/searchPageSelectors.spec.js
@@ -1,22 +1,20 @@
-import chai, { expect } from 'chai';
-import chaiImmutable from 'chai-immutable';
+import { expect } from 'chai';
 
-import { fromJS } from 'immutable';
+import _ from 'lodash';
+import Immutable from 'seamless-immutable';
 
 import { searchPageSelectors } from 'selectors/searchPageSelectors';
 
-chai.use(chaiImmutable);
-
 describe('Selectors: searchPageSelectors', () => {
   const state = {
-    search: fromJS({
+    search: Immutable({
       category: 'some-category',
       searchResults: {
         ids: ['r-1', 'r-2'],
         isFetching: true,
       },
     }),
-    resources: fromJS({
+    resources: Immutable({
       'r-1': { id: 'r-1', name: 'Some resource' },
       'r-2': { id: 'r-2', name: 'Other resource' },
     }),
@@ -25,17 +23,21 @@ describe('Selectors: searchPageSelectors', () => {
   describe('selected values', () => {
     it('should return category from the state', () => {
       const selected = searchPageSelectors(state);
+
       expect(selected.category).to.equal('some-category');
     });
 
     it('should return isFetchingSearchResults from the state', () => {
       const selected = searchPageSelectors(state);
-      expect(selected.isFetchingSearchResults).to.be.true;
+      const expected = state.search.searchResults.isFetching;
+
+      expect(selected.isFetchingSearchResults).to.equal(expected);
     });
 
     it('should return resources corresponding to searchResults.ids as results', () => {
       const selected = searchPageSelectors(state);
-      const expected = state.resources.toList();
+      const expected = _.values(state.resources);
+
       expect(selected.results).to.deep.equal(expected);
     });
   });

--- a/app/selectors/resourcePageSelectors.js
+++ b/app/selectors/resourcePageSelectors.js
@@ -1,5 +1,5 @@
-import { Map } from 'immutable';
 import { createSelector } from 'reselect';
+import Immutable from 'seamless-immutable';
 
 const idSelector = (state) => state.router.params.id;
 const resourcesSelector = (state) => state.resources;
@@ -10,7 +10,7 @@ export const resourcePageSelectors = createSelector(
   (id, resources) => {
     return {
       id,
-      resource: resources.get(id, Map()),
+      resource: resources[id] || Immutable({}),
     };
   }
 );

--- a/app/selectors/searchPageSelectors.js
+++ b/app/selectors/searchPageSelectors.js
@@ -1,8 +1,8 @@
 import { createSelector } from 'reselect';
 
-const categorySelector = (state) => state.search.get('category');
+const categorySelector = (state) => state.search.category;
 const resourcesSelector = (state) => state.resources;
-const searchResultsSelector = (state) => state.search.get('searchResults');
+const searchResultsSelector = (state) => state.search.searchResults;
 
 export const searchPageSelectors = createSelector(
   categorySelector,
@@ -11,8 +11,8 @@ export const searchPageSelectors = createSelector(
   (category, searchResults, resources) => {
     return {
       category,
-      isFetchingSearchResults: searchResults.get('isFetching'),
-      results: searchResults.get('ids').map((resourceId) => resources.get(resourceId)),
+      isFetchingSearchResults: searchResults.isFetching,
+      results: searchResults.ids.map(resourceId => resources[resourceId]),
     };
   }
 );

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "history": "^1.9.1",
     "humps": "^0.7.0",
-    "immutable": "^3.7.5",
     "isomorphic-fetch": "^2.1.1",
     "lodash": "^3.10.1",
     "moment": "^2.10.3",
@@ -17,7 +16,6 @@
     "react-bootstrap": "^0.25.100-react-pre.1",
     "react-document-title": "^2.0.0",
     "react-dom": "^0.14.0-rc1",
-    "react-immutable-proptypes": "^1.2.1",
     "react-loader": "git://github.com/dallonf/react-loader.git",
     "react-pure-render": "^1.0.2",
     "react-redux": "^3.0.0",
@@ -28,7 +26,8 @@
     "redux-api-middleware": "git://github.com/lraivio/redux-api-middleware.git#55743706938c2911b5bb5b1d87e8f7358a598d09",
     "redux-logger": "^0.0.1",
     "redux-react-router": "^1.0.0-beta3",
-    "reselect": "^1.1.0"
+    "reselect": "^1.1.0",
+    "seamless-immutable": "^4.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.0.3",
@@ -36,7 +35,6 @@
     "babel-core": "^5.8.25",
     "babel-eslint": "^4.1.3",
     "babel-loader": "^5.3.2",
-    "chai-immutable": "^1.3.0",
     "css-loader": "^0.19.0",
     "eslint": "^1.5.1",
     "eslint-config-airbnb": "^0.1.0",


### PR DESCRIPTION
Switches the codebase to use seamless-immutable instead of immutable-js for immutable data structures.
The many benefits are listed in #19.
Closes #19.