### PR TITLE
Update to latest version of redux-api-middleware

### DIFF
--- a/app/actions/resourceActions.js
+++ b/app/actions/resourceActions.js
@@ -3,6 +3,7 @@ import { CALL_API } from 'redux-api-middleware';
 import { API_URL } from 'constants/AppConstants';
 import types from 'constants/ActionTypes';
 import { resourceSchema } from 'middleware/Schemas';
+import { createTransformFunction } from 'utils/APIUtils';
 
 export default {
   fetchResource,
@@ -19,7 +20,7 @@ function fetchResource(id) {
       ],
       endpoint: `${API_URL}/resource/${id}`,
       method: 'GET',
-      schema: resourceSchema,
+      transform: createTransformFunction(resourceSchema),
     },
   };
 }
@@ -34,6 +35,7 @@ function fetchResources() {
       ],
       endpoint: `${API_URL}/resource`,
       method: 'GET',
+      transform: createTransformFunction(),
       bailout: (state) => {
         return !state.search.searchResults.shouldFetch;
       },

--- a/app/utils/APIUtils.js
+++ b/app/utils/APIUtils.js
@@ -1,0 +1,16 @@
+import { camelizeKeys } from 'humps';
+import { normalize } from 'normalizr';
+
+export default {
+  createTransformFunction,
+};
+
+function createTransformFunction(schema) {
+  return (json) => {
+    const camelizedJson = camelizeKeys(json);
+    if (schema) {
+      return normalize(camelizedJson, schema);
+    }
+    return camelizedJson;
+  };
+}

--- a/app/utils/__tests__/APIUtils.spec.js
+++ b/app/utils/__tests__/APIUtils.spec.js
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+
+import { resourceSchema } from 'middleware/Schemas';
+import { createTransformFunction } from 'utils/APIUtils';
+
+describe('Utils: APIUtils', () => {
+  describe('createTransformFunction', () => {
+    it('should return a function', () => {
+      expect(typeof createTransformFunction()).to.equal('function');
+    });
+
+    describe('the returned function', () => {
+      it('should camelize object keys', () => {
+        const transformFunction = createTransformFunction();
+        const initial = {
+          'some_key': {
+            'nested_key': 'value',
+          },
+        };
+        const expected = {
+          someKey: {
+            nestedKey: 'value',
+          },
+        };
+
+        expect(transformFunction(initial)).to.deep.equal(expected);
+      });
+
+      describe('if normalizr Schema is provided', () => {
+        it('should use the Schema to normalize data', () => {
+          const transformFunction = createTransformFunction(resourceSchema);
+          const initialResourceData = {
+            id: 'r-1',
+            unit: {
+              id: 'u-1',
+            },
+          };
+          const expectedResourceData = {
+            entities: {
+              resources: {
+                'r-1': { id: 'r-1', unit: 'u-1' },
+              },
+              units: {
+                'u-1': { id: 'u-1' },
+              },
+            },
+            result: 'r-1',
+          };
+
+          expect(transformFunction(initialResourceData)).to.deep.equal(expectedResourceData);
+        });
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-router-bootstrap": "^0.19.0",
     "redux": "^3.0.0",
     "redux-actions": "^0.8.0",
-    "redux-api-middleware": "git://github.com/lraivio/redux-api-middleware.git#55743706938c2911b5bb5b1d87e8f7358a598d09",
+    "redux-api-middleware": "^0.6.0",
     "redux-logger": "^0.0.1",
     "redux-react-router": "^1.0.0-beta3",
     "reselect": "^1.1.0",


### PR DESCRIPTION
No need to use a fork anymore to camelize keys.
The version 0.6.0 provides an option for a transform function for transforming the response data before it gets to reducers.
Refs #12.