### PR TITLE
Explicitly specify headers in API calls

### DIFF
--- a/app/actions/purposeActions.js
+++ b/app/actions/purposeActions.js
@@ -3,7 +3,11 @@ import { CALL_API } from 'redux-api-middleware';
 
 import types from 'constants/ActionTypes';
 import { purposeSchema } from 'middleware/Schemas';
-import { buildAPIUrl, createTransformFunction } from 'utils/APIUtils';
+import {
+  buildAPIUrl,
+  createTransformFunction,
+  getHeaders,
+} from 'utils/APIUtils';
 
 export default {
   fetchPurposes,
@@ -19,6 +23,7 @@ function fetchPurposes() {
       ],
       endpoint: buildAPIUrl('purpose'),
       method: 'GET',
+      headers: getHeaders(),
       transform: createTransformFunction(arrayOf(purposeSchema)),
       bailout: (state) => {
         return !state.api.shouldFetchPurposes;

--- a/app/actions/reservationActions.js
+++ b/app/actions/reservationActions.js
@@ -1,7 +1,7 @@
 import { CALL_API } from 'redux-api-middleware';
 
 import types from 'constants/ActionTypes';
-import { buildAPIUrl } from 'utils/APIUtils';
+import { buildAPIUrl, getHeaders } from 'utils/APIUtils';
 
 export default {
   makeReservation,
@@ -19,10 +19,7 @@ function makeReservation(reservation) {
       ],
       endpoint: url,
       method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-      },
+      headers: getHeaders(),
       body: JSON.stringify(reservation),
     },
   };

--- a/app/actions/resourceActions.js
+++ b/app/actions/resourceActions.js
@@ -3,7 +3,11 @@ import { CALL_API } from 'redux-api-middleware';
 
 import types from 'constants/ActionTypes';
 import { resourceSchema } from 'middleware/Schemas';
-import { buildAPIUrl, createTransformFunction } from 'utils/APIUtils';
+import {
+  buildAPIUrl,
+  createTransformFunction,
+  getHeaders,
+} from 'utils/APIUtils';
 import { pickSupportedFilters } from 'utils/DataUtils';
 
 export default {
@@ -23,6 +27,7 @@ function fetchResource(id, params = {}) {
       ],
       endpoint: url,
       method: 'GET',
+      headers: getHeaders(),
       transform: createTransformFunction(resourceSchema),
     },
   };
@@ -40,6 +45,7 @@ function fetchResources(filters = {}) {
       ],
       endpoint: url,
       method: 'GET',
+      headers: getHeaders(),
       transform: createTransformFunction(arrayOf(resourceSchema)),
       bailout: (state) => {
         return !state.api.shouldFetchSearchResults;

--- a/app/actions/unitActions.js
+++ b/app/actions/unitActions.js
@@ -3,7 +3,11 @@ import { CALL_API } from 'redux-api-middleware';
 
 import types from 'constants/ActionTypes';
 import { unitSchema } from 'middleware/Schemas';
-import { buildAPIUrl, createTransformFunction } from 'utils/APIUtils';
+import {
+  buildAPIUrl,
+  createTransformFunction,
+  getHeaders,
+} from 'utils/APIUtils';
 
 export default {
   fetchUnits,
@@ -19,6 +23,7 @@ function fetchUnits() {
       ],
       endpoint: buildAPIUrl('unit'),
       method: 'GET',
+      headers: getHeaders(),
       transform: createTransformFunction(arrayOf(unitSchema)),
       bailout: (state) => {
         return !state.api.shouldFetchUnits;

--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -9,6 +9,10 @@ export default {
     watch_and_listen: 'Katsoa tai kuunnella',
     events_and_exhibitions: 'Pitää yleisötilaisuuden',
   },
+  REQUIRED_API_HEADERS: {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+  },
   SUPPORTED_SEARCH_FILTERS: [
     'purpose',
     'search',

--- a/app/utils/APIUtils.js
+++ b/app/utils/APIUtils.js
@@ -2,11 +2,12 @@ import { camelizeKeys, decamelizeKeys } from 'humps';
 import _ from 'lodash';
 import { normalize } from 'normalizr';
 
-import { API_URL } from 'constants/AppConstants';
+import { API_URL, REQUIRED_API_HEADERS } from 'constants/AppConstants';
 
 export default {
   buildAPIUrl,
   createTransformFunction,
+  getHeaders,
   getSearchParamsString,
 };
 
@@ -30,6 +31,10 @@ function createTransformFunction(schema) {
     }
     return camelizedJson;
   };
+}
+
+function getHeaders(headers) {
+  return Object.assign({}, REQUIRED_API_HEADERS, headers);
 }
 
 function getSearchParamsString(params) {

--- a/app/utils/__tests__/APIUtils.spec.js
+++ b/app/utils/__tests__/APIUtils.spec.js
@@ -1,10 +1,11 @@
 import { expect } from 'chai';
 
-import { API_URL } from 'constants/AppConstants';
+import { API_URL, REQUIRED_API_HEADERS } from 'constants/AppConstants';
 import { resourceSchema } from 'middleware/Schemas';
 import {
   buildAPIUrl,
   createTransformFunction,
+  getHeaders,
   getSearchParamsString,
 } from 'utils/APIUtils';
 
@@ -78,6 +79,25 @@ describe('Utils: APIUtils', () => {
 
           expect(transformFunction(initialResourceData)).to.deep.equal(expectedResourceData);
         });
+      });
+    });
+  });
+
+  describe('getHeaders', () => {
+    describe('if no additional headers are specified', () => {
+      it('should return just the required headers', () => {
+        expect(getHeaders()).to.deep.equal(REQUIRED_API_HEADERS);
+      });
+    });
+
+    describe('if additional headers are specified', () => {
+      it('should return the required headers and the additional headers', () => {
+        const additionalHeaders = {
+          header: 'value',
+        };
+        const expected = Object.assign({}, REQUIRED_API_HEADERS, additionalHeaders);
+
+        expect(getHeaders(additionalHeaders)).to.deep.equal(expected);
       });
     });
   });


### PR DESCRIPTION
In Chrome the API calls were working without specifying
"Accept" and "Content-Type" headers as "application/json".
However API calls in Firefox were not working correctly.
This commit fixes the issue.
Closes #51.