### PR TITLE
Feature/81 refactor selectors

### DIFF
--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -8,7 +8,7 @@ import { pushState } from 'redux-router';
 import { logout } from 'actions/authActions';
 import Footer from 'components/layout/Footer';
 import Navbar from 'components/layout/Navbar';
-import { appSelectors } from 'selectors/appSelectors';
+import appSelector from 'selectors/containers/appSelector';
 
 export class UnconnectedApp extends Component {
   constructor(props) {
@@ -60,4 +60,4 @@ function mapDispatchToProps(dispatch) {
   return { actions: bindActionCreators(actionCreators, dispatch) };
 }
 
-export default connect(appSelectors, mapDispatchToProps)(UnconnectedApp);
+export default connect(appSelector, mapDispatchToProps)(UnconnectedApp);

--- a/app/containers/PurposeCategoryList.js
+++ b/app/containers/PurposeCategoryList.js
@@ -8,7 +8,7 @@ import { pushState } from 'redux-router';
 import { fetchPurposes } from 'actions/purposeActions';
 import { changeSearchFilters } from 'actions/uiActions';
 import PurposeCategory from 'components/purpose/PurposeCategory';
-import { purposeCategoryListSelectors } from 'selectors/purposeCategoryListSelectors';
+import purposeCategoryListSelector from 'selectors/containers/purposeCategoryListSelector';
 
 export class UnconnectedPurposeCategoryList extends Component {
   constructor(props) {
@@ -68,4 +68,4 @@ function mapDispatchToProps(dispatch) {
   return { actions: bindActionCreators(actionCreators, dispatch) };
 }
 
-export default connect(purposeCategoryListSelectors, mapDispatchToProps)(UnconnectedPurposeCategoryList);
+export default connect(purposeCategoryListSelector, mapDispatchToProps)(UnconnectedPurposeCategoryList);

--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -15,7 +15,7 @@ import {
 import DateHeader from 'components/common/DateHeader';
 import ConfirmReservationModal from 'components/reservation/ConfirmReservationModal';
 import TimeSlots from 'components/reservation/TimeSlots';
-import { reservationFormSelectors } from 'selectors/reservationFormSelectors';
+import reservationFormSelector from 'selectors/containers/reservationFormSelector';
 import { getDateStartAndEndTimes } from 'utils/TimeUtils';
 
 export class UnconnectedReservationForm extends Component {
@@ -117,4 +117,4 @@ function mapDispatchToProps(dispatch) {
   return { actions: bindActionCreators(actionCreators, dispatch) };
 }
 
-export default connect(reservationFormSelectors, mapDispatchToProps)(UnconnectedReservationForm);
+export default connect(reservationFormSelector, mapDispatchToProps)(UnconnectedReservationForm);

--- a/app/containers/ReservationPage.js
+++ b/app/containers/ReservationPage.js
@@ -11,7 +11,7 @@ import { fetchResource } from 'actions/resourceActions';
 import ResourceHeader from 'components/resource/ResourceHeader';
 import NotFoundPage from 'containers/NotFoundPage';
 import ReservationForm from 'containers/ReservationForm';
-import { reservationPageSelectors } from 'selectors/reservationPageSelectors';
+import reservationPageSelector from 'selectors/containers/reservationPageSelector';
 import { getAddressWithName, getName } from 'utils/DataUtils';
 import { getDateStartAndEndTimes } from 'utils/TimeUtils';
 
@@ -79,4 +79,4 @@ function mapDispatchToProps(dispatch) {
   return { actions: bindActionCreators(actionCreators, dispatch) };
 }
 
-export default connect(reservationPageSelectors, mapDispatchToProps)(UnconnectedReservationPage);
+export default connect(reservationPageSelector, mapDispatchToProps)(UnconnectedReservationPage);

--- a/app/containers/ResourcePage.js
+++ b/app/containers/ResourcePage.js
@@ -12,7 +12,7 @@ import ImagePanel from 'components/common/ImagePanel';
 import ResourceDetails from 'components/resource/ResourceDetails';
 import ResourceHeader from 'components/resource/ResourceHeader';
 import NotFoundPage from 'containers/NotFoundPage';
-import { resourcePageSelectors } from 'selectors/resourcePageSelectors';
+import resourcePageSelector from 'selectors/containers/resourcePageSelector';
 import {
   getAddressWithName,
   getDescription,
@@ -88,4 +88,4 @@ function mapDispatchToProps(dispatch) {
   return { actions: bindActionCreators(actionCreators, dispatch) };
 }
 
-export default connect(resourcePageSelectors, mapDispatchToProps)(UnconnectedResourcePage);
+export default connect(resourcePageSelector, mapDispatchToProps)(UnconnectedResourcePage);

--- a/app/containers/SearchControls.js
+++ b/app/containers/SearchControls.js
@@ -9,7 +9,7 @@ import { changeSearchFilters } from 'actions/uiActions';
 import DateHeader from 'components/common/DateHeader';
 import SearchFilters from 'components/search/SearchFilters';
 import SearchInput from 'components/search/SearchInput';
-import { searchControlsSelectors } from 'selectors/searchControlsSelectors';
+import searchControlsSelector from 'selectors/containers/searchControlsSelector';
 import { getFetchParamsFromFilters } from 'utils/SearchUtils';
 
 export class UnconnectedSearchControls extends Component {
@@ -84,4 +84,4 @@ function mapDispatchToProps(dispatch) {
   return { actions: bindActionCreators(actionCreators, dispatch) };
 }
 
-export default connect(searchControlsSelectors, mapDispatchToProps)(UnconnectedSearchControls);
+export default connect(searchControlsSelector, mapDispatchToProps)(UnconnectedSearchControls);

--- a/app/containers/SearchPage.js
+++ b/app/containers/SearchPage.js
@@ -7,7 +7,7 @@ import { fetchResources } from 'actions/resourceActions';
 import { fetchUnits } from 'actions/unitActions';
 import SearchResults from 'components/search/SearchResults';
 import SearchControls from 'containers/SearchControls';
-import { searchPageSelectors } from 'selectors/searchPageSelectors';
+import searchPageSelector from 'selectors/containers/searchPageSelector';
 import { getFetchParamsFromFilters } from 'utils/SearchUtils';
 
 export class UnconnectedSearchPage extends Component {
@@ -56,4 +56,4 @@ function mapDispatchToProps(dispatch) {
   return { actions: bindActionCreators(actionCreators, dispatch) };
 }
 
-export default connect(searchPageSelectors, mapDispatchToProps)(UnconnectedSearchPage);
+export default connect(searchPageSelector, mapDispatchToProps)(UnconnectedSearchPage);

--- a/app/selectors/__tests__/purposeCategoriesSelector.spec.js
+++ b/app/selectors/__tests__/purposeCategoriesSelector.spec.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+
+import _ from 'lodash';
+import Immutable from 'seamless-immutable';
+
+import Purpose from 'fixtures/Purpose';
+import purposeCategoriesSelector from 'selectors/purposeCategoriesSelector';
+
+function getState(purposes) {
+  return {
+    data: Immutable({
+      purposes: _.indexBy(purposes, 'id'),
+    }),
+  };
+}
+
+describe('Selector: purposeCategoriesSelector', () => {
+  const mainTypes = ['some-type', 'other-type'];
+  const purposes = [
+    Purpose.build({ mainType: mainTypes[0] }),
+    Purpose.build({ mainType: mainTypes[1] }),
+    Purpose.build({ mainType: mainTypes[0] }),
+  ];
+
+  it('should return an empty object if there are no purposes in state', () => {
+    const state = getState([]);
+    const actual = purposeCategoriesSelector(state);
+
+    expect(actual).to.deep.equal({});
+  });
+
+  it('should return purposes from the state grouped by mainType', () => {
+    const state = getState(purposes);
+    const actual = purposeCategoriesSelector(state);
+    const expected = Immutable({
+      [mainTypes[0]]: [purposes[0], purposes[2]],
+      [mainTypes[1]]: [purposes[1]],
+    });
+
+    expect(actual).to.deep.equal(expected);
+  });
+});

--- a/app/selectors/__tests__/purposeCategoryListSelectors.spec.js
+++ b/app/selectors/__tests__/purposeCategoryListSelectors.spec.js
@@ -1,29 +1,20 @@
 import { expect } from 'chai';
 
-import _ from 'lodash';
 import Immutable from 'seamless-immutable';
 
 import types from 'constants/ActionTypes';
-import Purpose from 'fixtures/Purpose';
 import { purposeCategoryListSelectors } from 'selectors/purposeCategoryListSelectors';
 
 describe('Selectors: purposeCategoryListSelectors', () => {
-  let purposes;
   let state;
 
   beforeEach(() => {
-    purposes = [
-      Purpose.build({ mainType: 'some-type' }),
-      Purpose.build({ mainType: 'other-type' }),
-      Purpose.build({ mainType: 'some-type' }),
-    ];
-
     state = {
       api: Immutable({
         activeRequests: [],
       }),
       data: Immutable({
-        purposes: _.indexBy(purposes, 'id'),
+        purposes: {},
       }),
     };
   });
@@ -43,18 +34,9 @@ describe('Selectors: purposeCategoryListSelectors', () => {
     });
   });
 
-  it('should return purposes grouped by mainType from the state', () => {
+  it('should return purposeCategories', () => {
     const selected = purposeCategoryListSelectors(state);
-    const expected = Immutable({
-      [purposes[0].mainType]: [
-        purposes[0],
-        purposes[2],
-      ],
-      [purposes[1].mainType]: [
-        purposes[1],
-      ],
-    });
 
-    expect(selected.purposeCategories).to.deep.equal(expected);
+    expect(selected.purposeCategories).to.exist;
   });
 });

--- a/app/selectors/__tests__/purposeCategoryListSelectors.spec.js
+++ b/app/selectors/__tests__/purposeCategoryListSelectors.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 
 import Immutable from 'seamless-immutable';
 
-import types from 'constants/ActionTypes';
 import { purposeCategoryListSelectors } from 'selectors/purposeCategoryListSelectors';
 
 describe('Selectors: purposeCategoryListSelectors', () => {
@@ -19,19 +18,10 @@ describe('Selectors: purposeCategoryListSelectors', () => {
     };
   });
 
-  describe('isFetchingPurposes', () => {
-    it('should return true if PURPOSES_GET_REQUEST is in activeRequests', () => {
-      state.api.activeRequests = [types.API.PURPOSES_GET_REQUEST];
-      const selected = purposeCategoryListSelectors(state);
+  it('should return isFetchingPurposes', () => {
+    const selected = purposeCategoryListSelectors(state);
 
-      expect(selected.isFetchingPurposes).to.equal(true);
-    });
-
-    it('should return false if PURPOSES_GET_REQUEST is not in activeRequests', () => {
-      const selected = purposeCategoryListSelectors(state);
-
-      expect(selected.isFetchingPurposes).to.equal(false);
-    });
+    expect(selected.isFetchingPurposes).to.exist;
   });
 
   it('should return purposeCategories', () => {

--- a/app/selectors/__tests__/purposeOptionsSelector.spec.js
+++ b/app/selectors/__tests__/purposeOptionsSelector.spec.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+
+import _ from 'lodash';
+import Immutable from 'seamless-immutable';
+
+import Purpose from 'fixtures/Purpose';
+import purposeOptionsSelector from 'selectors/purposeOptionsSelector';
+
+function getState(purposes) {
+  return {
+    data: Immutable({
+      purposes: _.indexBy(purposes, 'id'),
+    }),
+  };
+}
+
+describe('Selector: purposeOptionsSelector', () => {
+  const purposes = [
+    Purpose.build(),
+    Purpose.build(),
+  ];
+
+  it('should return an empty array if state contains no purposes', () => {
+    const state = getState([]);
+    const actual = purposeOptionsSelector(state);
+
+    expect(actual).to.deep.equal([]);
+  });
+
+  it('should return an option object for each purpose in state', () => {
+    const state = getState(purposes);
+    const actual = purposeOptionsSelector(state);
+
+    expect(actual.length).to.equal(purposes.length);
+  });
+
+  describe('a returned option object', () => {
+    const purpose = purposes[0];
+    const state = getState([purpose]);
+    const option = purposeOptionsSelector(state)[0];
+
+    it('should have purpose.id as its value property', () => {
+      expect(option.value).to.equal(purpose.id);
+    });
+
+    it('should have purpose.name.fi as its label property', () => {
+      expect(option.label).to.equal(purpose.name.fi);
+    });
+
+    it('should not contain other properties than value and label', () => {
+      const expected = { value: purpose.id, label: purpose.name.fi };
+
+      expect(option).to.deep.equal(expected);
+    });
+  });
+
+  it('should work for multiple purposes', () => {
+    const state = getState(purposes);
+    const actual = purposeOptionsSelector(state);
+    const expected = Immutable([
+      { value: purposes[0].id, label: purposes[0].name.fi },
+      { value: purposes[1].id, label: purposes[1].name.fi },
+    ]);
+
+    expect(actual).to.deep.equal(expected);
+  });
+});

--- a/app/selectors/__tests__/reservationDateSelector.spec.js
+++ b/app/selectors/__tests__/reservationDateSelector.spec.js
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import MockDate from 'mockdate';
+
+import Immutable from 'seamless-immutable';
+
+import reservationDateSelector from 'selectors/reservationDateSelector';
+
+function getState(date) {
+  return {
+    ui: Immutable({
+      reservation: {
+        date,
+      },
+    }),
+  };
+}
+
+describe('Selector: reservationDateSelector', () => {
+  it('should return the date if it is defined', () => {
+    const date = '2015-10-10';
+    const state = getState(date);
+    const actual = reservationDateSelector(state);
+
+    expect(actual).to.equal(date);
+  });
+
+  it('should return current date string if date is not defined', () => {
+    const state = getState('');
+    MockDate.set('2015-12-24T12:00:00Z');
+    const actual = reservationDateSelector(state);
+    MockDate.reset();
+    const expected = '2015-12-24';
+
+    expect(actual).to.equal(expected);
+  });
+});

--- a/app/selectors/__tests__/reservationFormSelectors.spec.js
+++ b/app/selectors/__tests__/reservationFormSelectors.spec.js
@@ -46,9 +46,7 @@ describe('Selectors: reservationFormSelectors', () => {
         },
         reservation: {
           date: '2015-10-10',
-          selected: [
-            '2015-12-12T12:00:00+03:00/2015-12-12T13:00:00+03:00',
-          ],
+          selected: [],
         },
       }),
     };
@@ -130,17 +128,10 @@ describe('Selectors: reservationFormSelectors', () => {
     expect(selected.selected).to.equal(expected);
   });
 
-  it('should return selectedReservations in correct form', () => {
+  it('should return selectedReservations', () => {
     const selected = reservationFormSelectors(state);
-    const expected = [
-      {
-        begin: '2015-12-12T12:00:00+03:00',
-        end: '2015-12-12T13:00:00+03:00',
-        resource: resource.id,
-      },
-    ];
 
-    expect(selected.selectedReservations).to.deep.equal(expected);
+    expect(selected.selectedReservations).to.exist;
   });
 
   describe('timeSlots', () => {

--- a/app/selectors/__tests__/reservationFormSelectors.spec.js
+++ b/app/selectors/__tests__/reservationFormSelectors.spec.js
@@ -4,7 +4,6 @@ import Immutable from 'seamless-immutable';
 import simple from 'simple-mock';
 
 import types from 'constants/ActionTypes';
-import ModalTypes from 'constants/ModalTypes';
 import Resource, { openingHours } from 'fixtures/Resource';
 import { reservationFormSelectors } from 'selectors/reservationFormSelectors';
 import TimeUtils from 'utils/TimeUtils';
@@ -50,19 +49,10 @@ describe('Selectors: reservationFormSelectors', () => {
     };
   });
 
-  describe('confirmReservationModalIsOpen', () => {
-    it('should return true if "CONFIRM_RESERVATION" is in open modals', () => {
-      state.ui.modals.open = [ModalTypes.CONFIRM_RESERVATION];
-      const selected = reservationFormSelectors(state);
+  it('should return confirmReservationModalIsOpen', () => {
+    const selected = reservationFormSelectors(state);
 
-      expect(selected.confirmReservationModalIsOpen).to.equal(true);
-    });
-
-    it('should return false if "CONFIRM_RESERVATION" is not in open modals', () => {
-      const selected = reservationFormSelectors(state);
-
-      expect(selected.confirmReservationModalIsOpen).to.equal(false);
-    });
+    expect(selected.confirmReservationModalIsOpen).to.exist;
   });
 
   it('should return date', () => {

--- a/app/selectors/__tests__/reservationFormSelectors.spec.js
+++ b/app/selectors/__tests__/reservationFormSelectors.spec.js
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import Immutable from 'seamless-immutable';
 import simple from 'simple-mock';
 
-import types from 'constants/ActionTypes';
 import Resource, { openingHours } from 'fixtures/Resource';
 import { reservationFormSelectors } from 'selectors/reservationFormSelectors';
 import TimeUtils from 'utils/TimeUtils';
@@ -68,19 +67,10 @@ describe('Selectors: reservationFormSelectors', () => {
     expect(selected.id).to.equal(expected);
   });
 
-  describe('isFetchingResource', () => {
-    it('should return true if RESOURCE_GET_REQUEST is in activeRequests', () => {
-      state.api.activeRequests = [types.API.RESOURCE_GET_REQUEST];
-      const selected = reservationFormSelectors(state);
+  it('should return isFetchingResource', () => {
+    const selected = reservationFormSelectors(state);
 
-      expect(selected.isFetchingResource).to.equal(true);
-    });
-
-    it('should return false if RESOURCE_GET_REQUEST is not in activeRequests', () => {
-      const selected = reservationFormSelectors(state);
-
-      expect(selected.isFetchingResource).to.equal(false);
-    });
+    expect(selected.isFetchingResource).to.exist;
   });
 
   describe('isMakingReservations', () => {

--- a/app/selectors/__tests__/reservationFormSelectors.spec.js
+++ b/app/selectors/__tests__/reservationFormSelectors.spec.js
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
 
-import moment from 'moment';
 import Immutable from 'seamless-immutable';
 import simple from 'simple-mock';
 
 import types from 'constants/ActionTypes';
-import { DATE_FORMAT } from 'constants/AppConstants';
 import ModalTypes from 'constants/ModalTypes';
 import Resource, { openingHours } from 'fixtures/Resource';
 import { reservationFormSelectors } from 'selectors/reservationFormSelectors';
@@ -67,6 +65,12 @@ describe('Selectors: reservationFormSelectors', () => {
     });
   });
 
+  it('should return date', () => {
+    const selected = reservationFormSelectors(state);
+
+    expect(selected.date).to.exist;
+  });
+
   it('should return the id in router.params.id', () => {
     const selected = reservationFormSelectors(state);
     const expected = state.router.params.id;
@@ -101,23 +105,6 @@ describe('Selectors: reservationFormSelectors', () => {
       const selected = reservationFormSelectors(state);
 
       expect(selected.isMakingReservations).to.equal(true);
-    });
-  });
-
-  describe('reservation date', () => {
-    it('should return the date if it is selected', () => {
-      const selected = reservationFormSelectors(state);
-      const expected = state.ui.reservation.date;
-
-      expect(selected.date).to.equal(expected);
-    });
-
-    it('should return current date string if date is not selected', () => {
-      state.ui.reservation.date = '';
-      const selected = reservationFormSelectors(state);
-      const expected = moment().format(DATE_FORMAT);
-
-      expect(selected.date).to.equal(expected);
     });
   });
 

--- a/app/selectors/__tests__/reservationPageSelectors.spec.js
+++ b/app/selectors/__tests__/reservationPageSelectors.spec.js
@@ -64,19 +64,10 @@ describe('Selectors: reservationPageSelectors', () => {
     expect(selected.isFetchingResource).to.exist;
   });
 
-  it('should return the resource corresponding to the router.params.id', () => {
-    const selected = reservationPageSelectors(state);
-    const resourceId = state.router.params.id;
-    const expected = state.data.resources[resourceId];
-
-    expect(selected.resource).to.deep.equal(expected);
-  });
-
-  it('should return an empty object as resource if resource with given id is not fetched', () => {
-    state.router.params.id = 'unfetched-resource-id';
+  it('should return resource', () => {
     const selected = reservationPageSelectors(state);
 
-    expect(selected.resource).to.deep.equal({});
+    expect(selected.resource).to.exist;
   });
 
   it('should return the unit corresponding to the resource.unit', () => {

--- a/app/selectors/__tests__/reservationPageSelectors.spec.js
+++ b/app/selectors/__tests__/reservationPageSelectors.spec.js
@@ -1,10 +1,8 @@
 import { expect } from 'chai';
 
-import moment from 'moment';
 import Immutable from 'seamless-immutable';
 
 import types from 'constants/ActionTypes';
-import { DATE_FORMAT } from 'constants/AppConstants';
 import Resource from 'fixtures/Resource';
 import Unit from 'fixtures/Unit';
 import { reservationPageSelectors } from 'selectors/reservationPageSelectors';
@@ -48,21 +46,10 @@ describe('Selectors: reservationPageSelectors', () => {
     };
   });
 
-  describe('reservation date', () => {
-    it('should return the date if it is selected', () => {
-      const selected = reservationPageSelectors(state);
-      const expected = state.ui.reservation.date;
+  it('should return date', () => {
+    const selected = reservationPageSelectors(state);
 
-      expect(selected.date).to.equal(expected);
-    });
-
-    it('should return current date string if date is not selected', () => {
-      state.ui.reservation.date = '';
-      const selected = reservationPageSelectors(state);
-      const expected = moment().format(DATE_FORMAT);
-
-      expect(selected.date).to.equal(expected);
-    });
+    expect(selected.date).to.exist;
   });
 
   it('should return the id in router.params.id', () => {

--- a/app/selectors/__tests__/reservationPageSelectors.spec.js
+++ b/app/selectors/__tests__/reservationPageSelectors.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 
 import Immutable from 'seamless-immutable';
 
-import types from 'constants/ActionTypes';
 import Resource from 'fixtures/Resource';
 import Unit from 'fixtures/Unit';
 import { reservationPageSelectors } from 'selectors/reservationPageSelectors';
@@ -59,19 +58,10 @@ describe('Selectors: reservationPageSelectors', () => {
     expect(selected.id).to.equal(expected);
   });
 
-  describe('isFetchingResource', () => {
-    it('should return true if RESOURCE_GET_REQUEST is in activeRequests', () => {
-      state.api.activeRequests = [types.API.RESOURCE_GET_REQUEST];
-      const selected = reservationPageSelectors(state);
+  it('should return isFetchingResource', () => {
+    const selected = reservationPageSelectors(state);
 
-      expect(selected.isFetchingResource).to.equal(true);
-    });
-
-    it('should return false if RESOURCE_GET_REQUEST is not in activeRequests', () => {
-      const selected = reservationPageSelectors(state);
-
-      expect(selected.isFetchingResource).to.equal(false);
-    });
+    expect(selected.isFetchingResource).to.exist;
   });
 
   it('should return the resource corresponding to the router.params.id', () => {

--- a/app/selectors/__tests__/resourcePageSelectors.spec.js
+++ b/app/selectors/__tests__/resourcePageSelectors.spec.js
@@ -53,19 +53,10 @@ describe('Selectors: resourcePageSelectors', () => {
     expect(selected.isFetchingResource).to.exist;
   });
 
-  it('should return the resource corresponding to the router.params.id', () => {
-    const selected = resourcePageSelectors(state);
-    const resourceId = state.router.params.id;
-    const expected = state.data.resources[resourceId];
-
-    expect(selected.resource).to.deep.equal(expected);
-  });
-
-  it('should return an empty object as resource if resource with given id is not fetched', () => {
-    state.router.params.id = 'unfetched-resource-id';
+  it('should return resource', () => {
     const selected = resourcePageSelectors(state);
 
-    expect(selected.resource).to.deep.equal({});
+    expect(selected.resource).to.exist;
   });
 
   it('should return the unit corresponding to the resource.unit', () => {

--- a/app/selectors/__tests__/resourcePageSelectors.spec.js
+++ b/app/selectors/__tests__/resourcePageSelectors.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 
 import Immutable from 'seamless-immutable';
 
-import types from 'constants/ActionTypes';
 import Resource from 'fixtures/Resource';
 import Unit from 'fixtures/Unit';
 import { resourcePageSelectors } from 'selectors/resourcePageSelectors';
@@ -48,19 +47,10 @@ describe('Selectors: resourcePageSelectors', () => {
     expect(selected.id).to.equal(expected);
   });
 
-  describe('isFetchingResource', () => {
-    it('should return true if RESOURCE_GET_REQUEST is in activeRequests', () => {
-      state.api.activeRequests = [types.API.RESOURCE_GET_REQUEST];
-      const selected = resourcePageSelectors(state);
+  it('should return isFetchingResource', () => {
+    const selected = resourcePageSelectors(state);
 
-      expect(selected.isFetchingResource).to.equal(true);
-    });
-
-    it('should return false if RESOURCE_GET_REQUEST is not in activeRequests', () => {
-      const selected = resourcePageSelectors(state);
-
-      expect(selected.isFetchingResource).to.equal(false);
-    });
+    expect(selected.isFetchingResource).to.exist;
   });
 
   it('should return the resource corresponding to the router.params.id', () => {

--- a/app/selectors/__tests__/resourceSelector.spec.js
+++ b/app/selectors/__tests__/resourceSelector.spec.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+
+import _ from 'lodash';
+import Immutable from 'seamless-immutable';
+
+import Resource from 'fixtures/Resource';
+import resourceSelector from 'selectors/resourceSelector';
+
+function getState(resources, id) {
+  return {
+    data: Immutable({
+      resources: _.indexBy(resources, 'id'),
+    }),
+    router: {
+      params: {
+        id,
+      },
+    },
+  };
+}
+
+describe('Selector: resourceSelector', () => {
+  it('should return the resource corresponding to the router.params.id', () => {
+    const resource = Resource.build();
+    const state = getState([resource], resource.id);
+    const actual = resourceSelector(state);
+
+    expect(actual).to.deep.equal(resource);
+  });
+
+  it('should return an empty object as resource if resource with given id is not fetched', () => {
+    const state = getState([], 'unfetched-id');
+    const actual = resourceSelector(state);
+
+    expect(actual).to.deep.equal({});
+  });
+});

--- a/app/selectors/__tests__/searchControlsSelectors.spec.js
+++ b/app/selectors/__tests__/searchControlsSelectors.spec.js
@@ -1,10 +1,8 @@
 import { expect } from 'chai';
 
-import moment from 'moment';
 import Immutable from 'seamless-immutable';
 
 import types from 'constants/ActionTypes';
-import { DATE_FORMAT } from 'constants/AppConstants';
 import Purpose from 'fixtures/Purpose';
 import { searchControlsSelectors } from 'selectors/searchControlsSelectors';
 
@@ -39,6 +37,12 @@ describe('Selectors: searchControlsSelectors', () => {
     };
   });
 
+  it('should return filters', () => {
+    const selected = searchControlsSelectors(state);
+
+    expect(selected.filters).to.exist;
+  });
+
   describe('isFetchingPurposes', () => {
     it('should return true if PURPOSES_GET_REQUEST is in activeRequests', () => {
       state.api.activeRequests = [types.API.PURPOSES_GET_REQUEST];
@@ -62,24 +66,5 @@ describe('Selectors: searchControlsSelectors', () => {
     ]);
 
     expect(selected.purposeOptions).to.deep.equal(expected);
-  });
-
-  describe('filters', () => {
-    it('should return filters from the state', () => {
-      const selected = searchControlsSelectors(state);
-      const expected = state.ui.search.filters;
-
-      expect(selected.filters).to.deep.equal(expected);
-    });
-
-    it('should return current date as date filter if date is an empty string in state', () => {
-      state.ui.search.filters.date = '';
-      const selected = searchControlsSelectors(state);
-      const filters = state.ui.search.filters;
-      const expectedDate = moment().format(DATE_FORMAT);
-      const expected = Object.assign({}, filters, { date: expectedDate });
-
-      expect(selected.filters).to.deep.equal(expected);
-    });
   });
 });

--- a/app/selectors/__tests__/searchControlsSelectors.spec.js
+++ b/app/selectors/__tests__/searchControlsSelectors.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 
 import Immutable from 'seamless-immutable';
 
-import types from 'constants/ActionTypes';
 import { searchControlsSelectors } from 'selectors/searchControlsSelectors';
 
 describe('Selectors: searchControlsSelectors', () => {
@@ -33,19 +32,10 @@ describe('Selectors: searchControlsSelectors', () => {
     expect(selected.filters).to.exist;
   });
 
-  describe('isFetchingPurposes', () => {
-    it('should return true if PURPOSES_GET_REQUEST is in activeRequests', () => {
-      state.api.activeRequests = [types.API.PURPOSES_GET_REQUEST];
-      const selected = searchControlsSelectors(state);
+  it('should return isFetchingPurposes', () => {
+    const selected = searchControlsSelectors(state);
 
-      expect(selected.isFetchingPurposes).to.equal(true);
-    });
-
-    it('should return false if PURPOSES_GET_REQUEST is not in activeRequests', () => {
-      const selected = searchControlsSelectors(state);
-
-      expect(selected.isFetchingPurposes).to.equal(false);
-    });
+    expect(selected.isFetchingPurposes).to.exist;
   });
 
   it('should return purposeOptions', () => {

--- a/app/selectors/__tests__/searchControlsSelectors.spec.js
+++ b/app/selectors/__tests__/searchControlsSelectors.spec.js
@@ -3,28 +3,18 @@ import { expect } from 'chai';
 import Immutable from 'seamless-immutable';
 
 import types from 'constants/ActionTypes';
-import Purpose from 'fixtures/Purpose';
 import { searchControlsSelectors } from 'selectors/searchControlsSelectors';
 
 describe('Selectors: searchControlsSelectors', () => {
-  let purposes;
   let state;
 
   beforeEach(() => {
-    purposes = [
-      Purpose.build(),
-      Purpose.build(),
-    ];
-
     state = {
       api: Immutable({
         activeRequests: [],
       }),
       data: Immutable({
-        purposes: {
-          [purposes[0].id]: purposes[0],
-          [purposes[1].id]: purposes[1],
-        },
+        purposes: {},
       }),
       ui: Immutable({
         search: {
@@ -58,13 +48,9 @@ describe('Selectors: searchControlsSelectors', () => {
     });
   });
 
-  it('should return objects containing values and labels as purposeOptions', () => {
+  it('should return purposeOptions', () => {
     const selected = searchControlsSelectors(state);
-    const expected = Immutable([
-      { value: purposes[0].id, label: purposes[0].name.fi },
-      { value: purposes[1].id, label: purposes[1].name.fi },
-    ]);
 
-    expect(selected.purposeOptions).to.deep.equal(expected);
+    expect(selected.purposeOptions).to.exist;
   });
 });

--- a/app/selectors/__tests__/searchFiltersSelector.spec.js
+++ b/app/selectors/__tests__/searchFiltersSelector.spec.js
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import MockDate from 'mockdate';
+
+import Immutable from 'seamless-immutable';
+
+import searchFiltersSelector from 'selectors/searchFiltersSelector';
+
+function getState(date = '2015-10-10') {
+  return {
+    ui: Immutable({
+      search: {
+        filters: {
+          date: date,
+          purpose: 'some-purpose',
+        },
+      },
+    }),
+  };
+}
+
+describe('Selector: searchFiltersSelector', () => {
+  it('should return search filters from the state', () => {
+    const state = getState();
+    const actual = searchFiltersSelector(state);
+    const expected = state.ui.search.filters;
+
+    expect(actual).to.deep.equal(expected);
+  });
+
+  it('should return current date as the date filter if date is an empty string in state', () => {
+    const state = getState('');
+    MockDate.set('2015-12-24T16:07:37Z');
+    const actual = searchFiltersSelector(state);
+    MockDate.reset();
+    const filters = state.ui.search.filters;
+    const expected = Object.assign({}, filters, { date: '2015-12-24' });
+
+    expect(actual).to.deep.equal(expected);
+  });
+});

--- a/app/selectors/__tests__/searchPageSelectors.spec.js
+++ b/app/selectors/__tests__/searchPageSelectors.spec.js
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
 
 import _ from 'lodash';
-import moment from 'moment';
 import Immutable from 'seamless-immutable';
 
 import types from 'constants/ActionTypes';
-import { DATE_FORMAT } from 'constants/AppConstants';
 import Resource from 'fixtures/Resource';
 import Unit from 'fixtures/Unit';
 import { searchPageSelectors } from 'selectors/searchPageSelectors';
@@ -48,6 +46,12 @@ describe('Selectors: searchPageSelectors', () => {
     };
   });
 
+  it('should return filters', () => {
+    const selected = searchPageSelectors(state);
+
+    expect(selected.filters).to.exist;
+  });
+
   describe('isFetchingSearchResults', () => {
     it('should return true if RESOURCES_GET_REQUEST is in activeRequests', () => {
       state.api.activeRequests = [types.API.RESOURCES_GET_REQUEST];
@@ -60,25 +64,6 @@ describe('Selectors: searchPageSelectors', () => {
       const selected = searchPageSelectors(state);
 
       expect(selected.isFetchingSearchResults).to.equal(false);
-    });
-  });
-
-  describe('filters', () => {
-    it('should return filters from the state', () => {
-      const selected = searchPageSelectors(state);
-      const expected = state.ui.search.filters;
-
-      expect(selected.filters).to.deep.equal(expected);
-    });
-
-    it('should return current date as date filter if date is an empty string in state', () => {
-      state.ui.search.filters.date = '';
-      const selected = searchPageSelectors(state);
-      const filters = state.ui.search.filters;
-      const expectedDate = moment().format(DATE_FORMAT);
-      const expected = Object.assign({}, filters, { date: expectedDate });
-
-      expect(selected.filters).to.deep.equal(expected);
     });
   });
 

--- a/app/selectors/__tests__/searchPageSelectors.spec.js
+++ b/app/selectors/__tests__/searchPageSelectors.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 
 import Immutable from 'seamless-immutable';
 
-import types from 'constants/ActionTypes';
 import Unit from 'fixtures/Unit';
 import { searchPageSelectors } from 'selectors/searchPageSelectors';
 
@@ -41,19 +40,10 @@ describe('Selectors: searchPageSelectors', () => {
     expect(selected.filters).to.exist;
   });
 
-  describe('isFetchingSearchResults', () => {
-    it('should return true if RESOURCES_GET_REQUEST is in activeRequests', () => {
-      state.api.activeRequests = [types.API.RESOURCES_GET_REQUEST];
-      const selected = searchPageSelectors(state);
+  it('should return isFetchingSearchResults', () => {
+    const selected = searchPageSelectors(state);
 
-      expect(selected.isFetchingSearchResults).to.equal(true);
-    });
-
-    it('should return false if RESOURCES_GET_REQUEST is not in activeRequests', () => {
-      const selected = searchPageSelectors(state);
-
-      expect(selected.isFetchingSearchResults).to.equal(false);
-    });
+    expect(selected.isFetchingSearchResults).to.exist;
   });
 
   it('should return results', () => {

--- a/app/selectors/__tests__/searchPageSelectors.spec.js
+++ b/app/selectors/__tests__/searchPageSelectors.spec.js
@@ -1,24 +1,16 @@
 import { expect } from 'chai';
 
-import _ from 'lodash';
 import Immutable from 'seamless-immutable';
 
 import types from 'constants/ActionTypes';
-import Resource from 'fixtures/Resource';
 import Unit from 'fixtures/Unit';
 import { searchPageSelectors } from 'selectors/searchPageSelectors';
 
 describe('Selectors: searchPageSelectors', () => {
   let unit;
-  let resources;
   let state;
 
   beforeEach(() => {
-    resources = [
-      Resource.build(),
-      Resource.build(),
-    ];
-
     unit = Unit.build();
 
     state = {
@@ -26,10 +18,7 @@ describe('Selectors: searchPageSelectors', () => {
         activeRequests: [],
       }),
       data: Immutable({
-        resources: {
-          [resources[0].id]: resources[0],
-          [resources[1].id]: resources[1],
-        },
+        resources: {},
         units: {
           [unit.id]: unit,
         },
@@ -40,7 +29,7 @@ describe('Selectors: searchPageSelectors', () => {
             date: '2015-10-10',
             purpose: 'some-purpose',
           },
-          results: [resources[0].id, resources[1].id],
+          results: [],
         },
       }),
     };
@@ -67,21 +56,10 @@ describe('Selectors: searchPageSelectors', () => {
     });
   });
 
-  it('should return resources corresponding to searchResults.ids as results', () => {
+  it('should return results', () => {
     const selected = searchPageSelectors(state);
-    const expected = [resources[0], resources[1]];
 
-    expect(selected.results).to.deep.equal(expected);
-  });
-
-  it('should return the results in alphabetical order', () => {
-    const unsortedResults = [resources[1].id, resources[0].id];
-    const unSortedState = _.merge({}, state, { ui: { search: { results: unsortedResults } } });
-
-    const selected = searchPageSelectors(unSortedState);
-    const expected = [resources[0], resources[1]];
-
-    expect(selected.results).to.deep.equal(expected);
+    expect(selected.results).to.exist;
   });
 
   it('should return units from the state', () => {

--- a/app/selectors/__tests__/searchResultsSelector.spec.js
+++ b/app/selectors/__tests__/searchResultsSelector.spec.js
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+
+import _ from 'lodash';
+import Immutable from 'seamless-immutable';
+
+import Resource from 'fixtures/Resource';
+import searchResultsSelector from 'selectors/searchResultsSelector';
+
+function getState(resources, results = []) {
+  return {
+    data: Immutable({
+      resources: _.indexBy(resources, 'id'),
+    }),
+    ui: Immutable({
+      search: {
+        results,
+      },
+    }),
+  };
+}
+
+describe('Selector: searchResultsSelector', () => {
+  const resources = [
+    Resource.build(),
+    Resource.build(),
+  ];
+
+  it('should return an empty string if results in state is empty', () => {
+    const results = [];
+    const state = getState(resources, results);
+    const actual = searchResultsSelector(state);
+
+    expect(actual).to.deep.equal([]);
+  });
+
+  it('should return resources corresponding to ids in search.results', () => {
+    const results = [resources[0].id, resources[1].id];
+    const state = getState(resources, results);
+    const actual = searchResultsSelector(state);
+    const expected = [resources[0], resources[1]];
+
+    expect(actual).to.deep.equal(expected);
+  });
+
+  it('should not return resources not specified in results', () => {
+    const results = [resources[0].id];
+    const state = getState(resources, results);
+    const actual = searchResultsSelector(state);
+    const expected = [resources[0]];
+
+    expect(actual).to.deep.equal(expected);
+  });
+
+  it('should return the results in alphabetical order', () => {
+    const unsortedResults = [resources[1].id, resources[0].id];
+    const state = getState(resources, unsortedResults);
+    const actual = searchResultsSelector(state);
+    const expected = [resources[0], resources[1]];
+
+    expect(actual).to.deep.equal(expected);
+  });
+});

--- a/app/selectors/__tests__/selectedReservationsSelector.spec.js
+++ b/app/selectors/__tests__/selectedReservationsSelector.spec.js
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+
+import Immutable from 'seamless-immutable';
+
+import selectedReservationsSelector from 'selectors/selectedReservationsSelector';
+
+function getState(selected) {
+  return {
+    router: {
+      params: {
+        id: 'some-id',
+      },
+    },
+    ui: Immutable({
+      reservation: {
+        selected,
+      },
+    }),
+  };
+}
+
+describe('Selector: selectedReservationsSelector', () => {
+  const selected = [
+    '2015-12-12T12:00:00+03:00/2015-12-12T13:00:00+03:00',
+    '2015-12-12T13:00:00+03:00/2015-12-12T14:00:00+03:00',
+  ];
+
+  it('should return an empty object if no reservations are selected', () => {
+    const state = getState([]);
+    const actual = selectedReservationsSelector(state);
+
+    expect(actual).to.deep.equal([]);
+  });
+
+  it('should return selectedReservations in correct form', () => {
+    const state = getState([selected[0]]);
+    const actual = selectedReservationsSelector(state);
+    const expected = [
+      {
+        begin: '2015-12-12T12:00:00+03:00',
+        end: '2015-12-12T13:00:00+03:00',
+        resource: 'some-id',
+      },
+    ];
+
+    expect(actual).to.deep.equal(expected);
+  });
+
+  it('should combine reservations that if they are continual', () => {
+    const state = getState(selected);
+    const actual = selectedReservationsSelector(state);
+    const expected = [
+      {
+        begin: '2015-12-12T12:00:00+03:00',
+        end: '2015-12-12T14:00:00+03:00',
+        resource: 'some-id',
+      },
+    ];
+
+    expect(actual).to.deep.equal(expected);
+  });
+});

--- a/app/selectors/containers/__tests__/appSelector.spec.js
+++ b/app/selectors/containers/__tests__/appSelector.spec.js
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import Immutable from 'seamless-immutable';
 
 import User from 'fixtures/User';
-import { appSelectors } from 'selectors/appSelectors';
+import appSelector from 'selectors/containers/appSelector';
 
-describe('Selectors: appSelectors', () => {
+describe('Selector: appSelector', () => {
   let state;
   let user;
 
@@ -25,14 +25,14 @@ describe('Selectors: appSelectors', () => {
   });
 
   it('should return user corresponding to the auth.userId', () => {
-    const selected = appSelectors(state);
+    const selected = appSelector(state);
 
     expect(selected.user).to.deep.equal(user);
   });
 
   it('should return an empty object if user is not logged in', () => {
     state.auth.userId = null;
-    const selected = appSelectors(state);
+    const selected = appSelector(state);
 
     expect(selected.user).to.deep.equal({});
   });

--- a/app/selectors/containers/__tests__/appSelector.spec.js
+++ b/app/selectors/containers/__tests__/appSelector.spec.js
@@ -1,37 +1,35 @@
 import { expect } from 'chai';
 
+import _ from 'lodash';
 import Immutable from 'seamless-immutable';
 
 import User from 'fixtures/User';
 import appSelector from 'selectors/containers/appSelector';
 
+function getState(users, loggedInUserId) {
+  return {
+    auth: Immutable({
+      userId: loggedInUserId,
+    }),
+    data: Immutable({
+      users: _.indexBy(users, 'id'),
+    }),
+  };
+}
+
 describe('Selector: appSelector', () => {
-  let state;
-  let user;
-
-  beforeEach(() => {
-    user = User.build();
-
-    state = {
-      auth: Immutable({
-        userId: user.id,
-      }),
-      data: Immutable({
-        users: {
-          [user.id]: user,
-        },
-      }),
-    };
-  });
+  const users = [User.build()];
 
   it('should return user corresponding to the auth.userId', () => {
+    const user = users[0];
+    const state = getState(users, user.id);
     const selected = appSelector(state);
 
     expect(selected.user).to.deep.equal(user);
   });
 
   it('should return an empty object if user is not logged in', () => {
-    state.auth.userId = null;
+    const state = getState(users, null);
     const selected = appSelector(state);
 
     expect(selected.user).to.deep.equal({});

--- a/app/selectors/containers/__tests__/purposeCategoryListSelector.spec.js
+++ b/app/selectors/containers/__tests__/purposeCategoryListSelector.spec.js
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 
 import Immutable from 'seamless-immutable';
 
-import { purposeCategoryListSelectors } from 'selectors/purposeCategoryListSelectors';
+import purposeCategoryListSelector from 'selectors/containers/purposeCategoryListSelector';
 
-describe('Selectors: purposeCategoryListSelectors', () => {
+describe('Selector: purposeCategoryListSelector', () => {
   let state;
 
   beforeEach(() => {
@@ -19,13 +19,13 @@ describe('Selectors: purposeCategoryListSelectors', () => {
   });
 
   it('should return isFetchingPurposes', () => {
-    const selected = purposeCategoryListSelectors(state);
+    const selected = purposeCategoryListSelector(state);
 
     expect(selected.isFetchingPurposes).to.exist;
   });
 
   it('should return purposeCategories', () => {
-    const selected = purposeCategoryListSelectors(state);
+    const selected = purposeCategoryListSelector(state);
 
     expect(selected.purposeCategories).to.exist;
   });

--- a/app/selectors/containers/__tests__/purposeCategoryListSelector.spec.js
+++ b/app/selectors/containers/__tests__/purposeCategoryListSelector.spec.js
@@ -1,32 +1,17 @@
 import { expect } from 'chai';
 
-import Immutable from 'seamless-immutable';
-
+import { getInitialState } from 'utils/TestUtils';
 import purposeCategoryListSelector from 'selectors/containers/purposeCategoryListSelector';
 
 describe('Selector: purposeCategoryListSelector', () => {
-  let state;
-
-  beforeEach(() => {
-    state = {
-      api: Immutable({
-        activeRequests: [],
-      }),
-      data: Immutable({
-        purposes: {},
-      }),
-    };
-  });
+  const state = getInitialState();
+  const selected = purposeCategoryListSelector(state);
 
   it('should return isFetchingPurposes', () => {
-    const selected = purposeCategoryListSelector(state);
-
     expect(selected.isFetchingPurposes).to.exist;
   });
 
   it('should return purposeCategories', () => {
-    const selected = purposeCategoryListSelector(state);
-
     expect(selected.purposeCategories).to.exist;
   });
 });

--- a/app/selectors/containers/__tests__/reservationFormSelector.spec.js
+++ b/app/selectors/containers/__tests__/reservationFormSelector.spec.js
@@ -4,10 +4,10 @@ import Immutable from 'seamless-immutable';
 import simple from 'simple-mock';
 
 import Resource, { openingHours } from 'fixtures/Resource';
-import { reservationFormSelectors } from 'selectors/reservationFormSelectors';
+import reservationFormSelector from 'selectors/containers/reservationFormSelector';
 import TimeUtils from 'utils/TimeUtils';
 
-describe('Selectors: reservationFormSelectors', () => {
+describe('Selector: reservationFormSelector', () => {
   let resource;
   let state;
 
@@ -49,54 +49,54 @@ describe('Selectors: reservationFormSelectors', () => {
   });
 
   it('should return confirmReservationModalIsOpen', () => {
-    const selected = reservationFormSelectors(state);
+    const selected = reservationFormSelector(state);
 
     expect(selected.confirmReservationModalIsOpen).to.exist;
   });
 
   it('should return date', () => {
-    const selected = reservationFormSelectors(state);
+    const selected = reservationFormSelector(state);
 
     expect(selected.date).to.exist;
   });
 
   it('should return the id in router.params.id', () => {
-    const selected = reservationFormSelectors(state);
+    const selected = reservationFormSelector(state);
     const expected = state.router.params.id;
 
     expect(selected.id).to.equal(expected);
   });
 
   it('should return isFetchingResource', () => {
-    const selected = reservationFormSelectors(state);
+    const selected = reservationFormSelector(state);
 
     expect(selected.isFetchingResource).to.exist;
   });
 
   describe('isMakingReservations', () => {
     it('should be false if pendingReservationsCount is 0', () => {
-      const selected = reservationFormSelectors(state);
+      const selected = reservationFormSelector(state);
 
       expect(selected.isMakingReservations).to.equal(false);
     });
 
     it('should be true if pendingReservationsCount is more than 0', () => {
       state.api.pendingReservationsCount = 1;
-      const selected = reservationFormSelectors(state);
+      const selected = reservationFormSelector(state);
 
       expect(selected.isMakingReservations).to.equal(true);
     });
   });
 
   it('should return the reservation.selected from the state', () => {
-    const selected = reservationFormSelectors(state);
+    const selected = reservationFormSelector(state);
     const expected = state.ui.reservation.selected;
 
     expect(selected.selected).to.equal(expected);
   });
 
   it('should return selectedReservations', () => {
-    const selected = reservationFormSelectors(state);
+    const selected = reservationFormSelector(state);
 
     expect(selected.selectedReservations).to.exist;
   });
@@ -105,7 +105,7 @@ describe('Selectors: reservationFormSelectors', () => {
     it('should use resource properties to calculate correct time slots', () => {
       const mockSlots = ['slot-1', 'slot-2'];
       simple.mock(TimeUtils, 'getTimeSlots').returnWith(mockSlots);
-      const selected = reservationFormSelectors(state);
+      const selected = reservationFormSelector(state);
       const actualArgs = TimeUtils.getTimeSlots.lastCall.args;
 
       expect(actualArgs[0]).to.equal(resource.openingHours[0].opens);
@@ -118,7 +118,7 @@ describe('Selectors: reservationFormSelectors', () => {
 
     it('should return timeSlots as an empty array when resource is not found', () => {
       state.router.params.id = 'unfetched-resource-id';
-      const selected = reservationFormSelectors(state);
+      const selected = reservationFormSelector(state);
 
       expect(selected.timeSlots).to.deep.equal([]);
     });

--- a/app/selectors/containers/__tests__/reservationPageSelector.spec.js
+++ b/app/selectors/containers/__tests__/reservationPageSelector.spec.js
@@ -1,57 +1,44 @@
 import { expect } from 'chai';
 
+import _ from 'lodash';
 import Immutable from 'seamless-immutable';
 
 import Resource from 'fixtures/Resource';
 import Unit from 'fixtures/Unit';
 import reservationPageSelector from 'selectors/containers/reservationPageSelector';
 
-describe('Selector: reservationPageSelector', () => {
-  let resources;
-  let unit;
-  let state;
-
-  beforeEach(() => {
-    unit = Unit.build();
-
-    resources = [
-      Resource.build({ unit: unit.id }),
-      Resource.build({ unit: 'unfetched-id' }),
-    ];
-
-    state = {
-      api: Immutable({
-        activeRequests: [],
-      }),
-      data: Immutable({
-        resources: {
-          [resources[0].id]: resources[0],
-          [resources[1].id]: resources[1],
-        },
-        units: {
-          [unit.id]: unit,
-        },
-      }),
-      router: {
-        params: {
-          id: resources[0].id,
-        },
+function getState(resources = [], units = [], resourceId = 'some-id') {
+  return {
+    api: Immutable({
+      activeRequests: [],
+    }),
+    data: Immutable({
+      resources: _.indexBy(resources, 'id'),
+      units: _.indexBy(units, 'id'),
+    }),
+    router: {
+      params: {
+        id: resourceId,
       },
-      ui: Immutable({
-        reservation: {
-          date: '2015-10-10',
-        },
-      }),
-    };
-  });
+    },
+    ui: Immutable({
+      reservation: {
+        date: '2015-10-10',
+      },
+    }),
+  };
+}
 
+describe('Selector: reservationPageSelector', () => {
   it('should return date', () => {
+    const state = getState();
     const selected = reservationPageSelector(state);
 
     expect(selected.date).to.exist;
   });
 
   it('should return the id in router.params.id', () => {
+    const state = getState();
     const selected = reservationPageSelector(state);
     const expected = state.router.params.id;
 
@@ -59,33 +46,38 @@ describe('Selector: reservationPageSelector', () => {
   });
 
   it('should return isFetchingResource', () => {
+    const state = getState();
     const selected = reservationPageSelector(state);
 
     expect(selected.isFetchingResource).to.exist;
   });
 
   it('should return resource', () => {
+    const state = getState();
     const selected = reservationPageSelector(state);
 
     expect(selected.resource).to.exist;
   });
 
   it('should return the unit corresponding to the resource.unit', () => {
+    const unit = Unit.build();
+    const resource = Resource.build({ unit: unit.id });
+    const state = getState([resource], [unit], resource.id);
     const selected = reservationPageSelector(state);
-    const expected = unit;
 
-    expect(selected.unit).to.deep.equal(expected);
+    expect(selected.unit).to.deep.equal(unit);
   });
 
   it('should return an empty object as the unit if unit with the given id is not fetched', () => {
-    state.router.params.id = resources[1].id;
+    const resource = Resource.build();
+    const state = getState([resource], [], resource.id);
     const selected = reservationPageSelector(state);
 
     expect(selected.unit).to.deep.equal({});
   });
 
   it('should return an empty object as the unit if resource is not fetched', () => {
-    state.router.params.id = 'unfetched-id';
+    const state = getState([], [], 'unfetched-id');
     const selected = reservationPageSelector(state);
 
     expect(selected.unit).to.deep.equal({});

--- a/app/selectors/containers/__tests__/reservationPageSelector.spec.js
+++ b/app/selectors/containers/__tests__/reservationPageSelector.spec.js
@@ -4,9 +4,9 @@ import Immutable from 'seamless-immutable';
 
 import Resource from 'fixtures/Resource';
 import Unit from 'fixtures/Unit';
-import { reservationPageSelectors } from 'selectors/reservationPageSelectors';
+import reservationPageSelector from 'selectors/containers/reservationPageSelector';
 
-describe('Selectors: reservationPageSelectors', () => {
+describe('Selector: reservationPageSelector', () => {
   let resources;
   let unit;
   let state;
@@ -46,32 +46,32 @@ describe('Selectors: reservationPageSelectors', () => {
   });
 
   it('should return date', () => {
-    const selected = reservationPageSelectors(state);
+    const selected = reservationPageSelector(state);
 
     expect(selected.date).to.exist;
   });
 
   it('should return the id in router.params.id', () => {
-    const selected = reservationPageSelectors(state);
+    const selected = reservationPageSelector(state);
     const expected = state.router.params.id;
 
     expect(selected.id).to.equal(expected);
   });
 
   it('should return isFetchingResource', () => {
-    const selected = reservationPageSelectors(state);
+    const selected = reservationPageSelector(state);
 
     expect(selected.isFetchingResource).to.exist;
   });
 
   it('should return resource', () => {
-    const selected = reservationPageSelectors(state);
+    const selected = reservationPageSelector(state);
 
     expect(selected.resource).to.exist;
   });
 
   it('should return the unit corresponding to the resource.unit', () => {
-    const selected = reservationPageSelectors(state);
+    const selected = reservationPageSelector(state);
     const expected = unit;
 
     expect(selected.unit).to.deep.equal(expected);
@@ -79,14 +79,14 @@ describe('Selectors: reservationPageSelectors', () => {
 
   it('should return an empty object as the unit if unit with the given id is not fetched', () => {
     state.router.params.id = resources[1].id;
-    const selected = reservationPageSelectors(state);
+    const selected = reservationPageSelector(state);
 
     expect(selected.unit).to.deep.equal({});
   });
 
   it('should return an empty object as the unit if resource is not fetched', () => {
     state.router.params.id = 'unfetched-id';
-    const selected = reservationPageSelectors(state);
+    const selected = reservationPageSelector(state);
 
     expect(selected.unit).to.deep.equal({});
   });

--- a/app/selectors/containers/__tests__/resourcePageSelector.spec.js
+++ b/app/selectors/containers/__tests__/resourcePageSelector.spec.js
@@ -4,9 +4,9 @@ import Immutable from 'seamless-immutable';
 
 import Resource from 'fixtures/Resource';
 import Unit from 'fixtures/Unit';
-import { resourcePageSelectors } from 'selectors/resourcePageSelectors';
+import resourcePageSelector from 'selectors/containers/resourcePageSelector';
 
-describe('Selectors: resourcePageSelectors', () => {
+describe('Selector: resourcePageSelector', () => {
   let resources;
   let unit;
   let state;
@@ -41,26 +41,26 @@ describe('Selectors: resourcePageSelectors', () => {
   });
 
   it('should return the id in router.params.id', () => {
-    const selected = resourcePageSelectors(state);
+    const selected = resourcePageSelector(state);
     const expected = state.router.params.id;
 
     expect(selected.id).to.equal(expected);
   });
 
   it('should return isFetchingResource', () => {
-    const selected = resourcePageSelectors(state);
+    const selected = resourcePageSelector(state);
 
     expect(selected.isFetchingResource).to.exist;
   });
 
   it('should return resource', () => {
-    const selected = resourcePageSelectors(state);
+    const selected = resourcePageSelector(state);
 
     expect(selected.resource).to.exist;
   });
 
   it('should return the unit corresponding to the resource.unit', () => {
-    const selected = resourcePageSelectors(state);
+    const selected = resourcePageSelector(state);
     const expected = unit;
 
     expect(selected.unit).to.deep.equal(expected);
@@ -68,14 +68,14 @@ describe('Selectors: resourcePageSelectors', () => {
 
   it('should return an empty object as the unit if unit with the given id is not fetched', () => {
     state.router.params.id = resources[1].id;
-    const selected = resourcePageSelectors(state);
+    const selected = resourcePageSelector(state);
 
     expect(selected.unit).to.deep.equal({});
   });
 
   it('should return an empty object as the unit if resource is not fetched', () => {
     state.router.params.id = 'unfetched-id';
-    const selected = resourcePageSelectors(state);
+    const selected = resourcePageSelector(state);
 
     expect(selected.unit).to.deep.equal({});
   });

--- a/app/selectors/containers/__tests__/resourcePageSelector.spec.js
+++ b/app/selectors/containers/__tests__/resourcePageSelector.spec.js
@@ -1,46 +1,32 @@
 import { expect } from 'chai';
 
+import _ from 'lodash';
 import Immutable from 'seamless-immutable';
 
 import Resource from 'fixtures/Resource';
 import Unit from 'fixtures/Unit';
 import resourcePageSelector from 'selectors/containers/resourcePageSelector';
 
-describe('Selector: resourcePageSelector', () => {
-  let resources;
-  let unit;
-  let state;
-
-  beforeEach(() => {
-    unit = Unit.build();
-
-    resources = [
-      Resource.build({ unit: unit.id }),
-      Resource.build({ unit: 'unfetched-id' }),
-    ];
-
-    state = {
-      api: Immutable({
-        activeRequests: [],
-      }),
-      data: Immutable({
-        resources: {
-          [resources[0].id]: resources[0],
-          [resources[1].id]: resources[1],
-        },
-        units: {
-          [unit.id]: unit,
-        },
-      }),
-      router: {
-        params: {
-          id: resources[0].id,
-        },
+function getState(resources = [], units = [], resourceId = 'some-id') {
+  return {
+    api: Immutable({
+      activeRequests: [],
+    }),
+    data: Immutable({
+      resources: _.indexBy(resources, 'id'),
+      units: _.indexBy(units, 'id'),
+    }),
+    router: {
+      params: {
+        id: resourceId,
       },
-    };
-  });
+    },
+  };
+}
 
+describe('Selector: resourcePageSelector', () => {
   it('should return the id in router.params.id', () => {
+    const state = getState();
     const selected = resourcePageSelector(state);
     const expected = state.router.params.id;
 
@@ -48,33 +34,38 @@ describe('Selector: resourcePageSelector', () => {
   });
 
   it('should return isFetchingResource', () => {
+    const state = getState();
     const selected = resourcePageSelector(state);
 
     expect(selected.isFetchingResource).to.exist;
   });
 
   it('should return resource', () => {
+    const state = getState();
     const selected = resourcePageSelector(state);
 
     expect(selected.resource).to.exist;
   });
 
   it('should return the unit corresponding to the resource.unit', () => {
+    const unit = Unit.build();
+    const resource = Resource.build({ unit: unit.id });
+    const state = getState([resource], [unit], resource.id);
     const selected = resourcePageSelector(state);
-    const expected = unit;
 
-    expect(selected.unit).to.deep.equal(expected);
+    expect(selected.unit).to.deep.equal(unit);
   });
 
   it('should return an empty object as the unit if unit with the given id is not fetched', () => {
-    state.router.params.id = resources[1].id;
+    const resource = Resource.build();
+    const state = getState([resource], [], resource.id);
     const selected = resourcePageSelector(state);
 
     expect(selected.unit).to.deep.equal({});
   });
 
   it('should return an empty object as the unit if resource is not fetched', () => {
-    state.router.params.id = 'unfetched-id';
+    const state = getState([], [], 'unfetched-id');
     const selected = resourcePageSelector(state);
 
     expect(selected.unit).to.deep.equal({});

--- a/app/selectors/containers/__tests__/searchControlsSelector.spec.js
+++ b/app/selectors/containers/__tests__/searchControlsSelector.spec.js
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 
 import Immutable from 'seamless-immutable';
 
-import { searchControlsSelectors } from 'selectors/searchControlsSelectors';
+import searchControlsSelector from 'selectors/containers/searchControlsSelector';
 
-describe('Selectors: searchControlsSelectors', () => {
+describe('Selector: searchControlsSelector', () => {
   let state;
 
   beforeEach(() => {
@@ -27,19 +27,19 @@ describe('Selectors: searchControlsSelectors', () => {
   });
 
   it('should return filters', () => {
-    const selected = searchControlsSelectors(state);
+    const selected = searchControlsSelector(state);
 
     expect(selected.filters).to.exist;
   });
 
   it('should return isFetchingPurposes', () => {
-    const selected = searchControlsSelectors(state);
+    const selected = searchControlsSelector(state);
 
     expect(selected.isFetchingPurposes).to.exist;
   });
 
   it('should return purposeOptions', () => {
-    const selected = searchControlsSelectors(state);
+    const selected = searchControlsSelector(state);
 
     expect(selected.purposeOptions).to.exist;
   });

--- a/app/selectors/containers/__tests__/searchControlsSelector.spec.js
+++ b/app/selectors/containers/__tests__/searchControlsSelector.spec.js
@@ -1,46 +1,21 @@
 import { expect } from 'chai';
 
-import Immutable from 'seamless-immutable';
-
 import searchControlsSelector from 'selectors/containers/searchControlsSelector';
+import { getInitialState } from 'utils/TestUtils';
 
 describe('Selector: searchControlsSelector', () => {
-  let state;
-
-  beforeEach(() => {
-    state = {
-      api: Immutable({
-        activeRequests: [],
-      }),
-      data: Immutable({
-        purposes: {},
-      }),
-      ui: Immutable({
-        search: {
-          filters: {
-            date: '2015-10-10',
-            purpose: 'some-purpose',
-          },
-        },
-      }),
-    };
-  });
+  const state = getInitialState();
+  const selected = searchControlsSelector(state);
 
   it('should return filters', () => {
-    const selected = searchControlsSelector(state);
-
     expect(selected.filters).to.exist;
   });
 
   it('should return isFetchingPurposes', () => {
-    const selected = searchControlsSelector(state);
-
     expect(selected.isFetchingPurposes).to.exist;
   });
 
   it('should return purposeOptions', () => {
-    const selected = searchControlsSelector(state);
-
     expect(selected.purposeOptions).to.exist;
   });
 });

--- a/app/selectors/containers/__tests__/searchPageSelector.spec.js
+++ b/app/selectors/containers/__tests__/searchPageSelector.spec.js
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import Immutable from 'seamless-immutable';
 
 import Unit from 'fixtures/Unit';
-import { searchPageSelectors } from 'selectors/searchPageSelectors';
+import searchPageSelector from 'selectors/containers/searchPageSelector';
 
-describe('Selectors: searchPageSelectors', () => {
+describe('Selector: searchPageSelector', () => {
   let unit;
   let state;
 
@@ -35,25 +35,25 @@ describe('Selectors: searchPageSelectors', () => {
   });
 
   it('should return filters', () => {
-    const selected = searchPageSelectors(state);
+    const selected = searchPageSelector(state);
 
     expect(selected.filters).to.exist;
   });
 
   it('should return isFetchingSearchResults', () => {
-    const selected = searchPageSelectors(state);
+    const selected = searchPageSelector(state);
 
     expect(selected.isFetchingSearchResults).to.exist;
   });
 
   it('should return results', () => {
-    const selected = searchPageSelectors(state);
+    const selected = searchPageSelector(state);
 
     expect(selected.results).to.exist;
   });
 
   it('should return units from the state', () => {
-    const selected = searchPageSelectors(state);
+    const selected = searchPageSelector(state);
     const expected = state.data.units;
 
     expect(selected.units).to.deep.equal(expected);

--- a/app/selectors/containers/__tests__/searchPageSelector.spec.js
+++ b/app/selectors/containers/__tests__/searchPageSelector.spec.js
@@ -1,59 +1,25 @@
 import { expect } from 'chai';
 
-import Immutable from 'seamless-immutable';
-
-import Unit from 'fixtures/Unit';
 import searchPageSelector from 'selectors/containers/searchPageSelector';
+import { getInitialState } from 'utils/TestUtils';
 
 describe('Selector: searchPageSelector', () => {
-  let unit;
-  let state;
-
-  beforeEach(() => {
-    unit = Unit.build();
-
-    state = {
-      api: Immutable({
-        activeRequests: [],
-      }),
-      data: Immutable({
-        resources: {},
-        units: {
-          [unit.id]: unit,
-        },
-      }),
-      ui: Immutable({
-        search: {
-          filters: {
-            date: '2015-10-10',
-            purpose: 'some-purpose',
-          },
-          results: [],
-        },
-      }),
-    };
-  });
+  const state = getInitialState();
+  const selected = searchPageSelector(state);
 
   it('should return filters', () => {
-    const selected = searchPageSelector(state);
-
     expect(selected.filters).to.exist;
   });
 
   it('should return isFetchingSearchResults', () => {
-    const selected = searchPageSelector(state);
-
     expect(selected.isFetchingSearchResults).to.exist;
   });
 
   it('should return results', () => {
-    const selected = searchPageSelector(state);
-
     expect(selected.results).to.exist;
   });
 
   it('should return units from the state', () => {
-    const selected = searchPageSelector(state);
     const expected = state.data.units;
 
     expect(selected.units).to.deep.equal(expected);

--- a/app/selectors/containers/appSelector.js
+++ b/app/selectors/containers/appSelector.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 const userIdSelector = (state) => state.auth.userId;
 const usersSelector = (state) => state.data.users;
 
-export const appSelectors = createSelector(
+const appSelector = createSelector(
   userIdSelector,
   usersSelector,
   (
@@ -17,3 +17,5 @@ export const appSelectors = createSelector(
     };
   }
 );
+
+export default appSelector;

--- a/app/selectors/containers/purposeCategoryListSelector.js
+++ b/app/selectors/containers/purposeCategoryListSelector.js
@@ -4,7 +4,7 @@ import ActionTypes from 'constants/ActionTypes';
 import purposeCategoriesSelector from 'selectors/purposeCategoriesSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
-export const purposeCategoryListSelectors = createSelector(
+const purposeCategoryListSelector = createSelector(
   purposeCategoriesSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.PURPOSES_GET_REQUEST),
   (
@@ -17,3 +17,5 @@ export const purposeCategoryListSelectors = createSelector(
     };
   }
 );
+
+export default purposeCategoryListSelector;

--- a/app/selectors/containers/reservationFormSelector.js
+++ b/app/selectors/containers/reservationFormSelector.js
@@ -10,10 +10,12 @@ import { getOpeningHours } from 'utils/DataUtils';
 import { getTimeSlots } from 'utils/TimeUtils';
 import ModalTypes from 'constants/ModalTypes';
 
+const idSelector = (state) => state.router.params.id;
 const pendingReservationsCountSelector = (state) => state.api.pendingReservationsCount;
 const selectedSelector = (state) => state.ui.reservation.selected;
 
 const reservationFormSelector = createSelector(
+  idSelector,
   modalIsOpenSelectorFactory(ModalTypes.CONFIRM_RESERVATION),
   pendingReservationsCountSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
@@ -22,6 +24,7 @@ const reservationFormSelector = createSelector(
   selectedSelector,
   selectedReservationsSelector,
   (
+    id,
     confirmReservationModalIsOpen,
     pendingReservationsCount,
     isFetchingResource,
@@ -38,7 +41,7 @@ const reservationFormSelector = createSelector(
     return {
       confirmReservationModalIsOpen,
       date: reservationDate,
-      id: resource.id,
+      id,
       isFetchingResource,
       isMakingReservations: Boolean(pendingReservationsCount),
       selected,

--- a/app/selectors/containers/reservationFormSelector.js
+++ b/app/selectors/containers/reservationFormSelector.js
@@ -13,7 +13,7 @@ import ModalTypes from 'constants/ModalTypes';
 const pendingReservationsCountSelector = (state) => state.api.pendingReservationsCount;
 const selectedSelector = (state) => state.ui.reservation.selected;
 
-export const reservationFormSelectors = createSelector(
+const reservationFormSelector = createSelector(
   modalIsOpenSelectorFactory(ModalTypes.CONFIRM_RESERVATION),
   pendingReservationsCountSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
@@ -47,3 +47,5 @@ export const reservationFormSelectors = createSelector(
     };
   }
 );
+
+export default reservationFormSelector;

--- a/app/selectors/containers/reservationPageSelector.js
+++ b/app/selectors/containers/reservationPageSelector.js
@@ -5,14 +5,17 @@ import resourceSelector from 'selectors/resourceSelector';
 import reservationDateSelector from 'selectors/reservationDateSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
+const idSelector = (state) => state.router.params.id;
 const unitsSelector = (state) => state.data.units;
 
 const reservationPageSelector = createSelector(
+  idSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   reservationDateSelector,
   resourceSelector,
   unitsSelector,
   (
+    id,
     isFetchingResource,
     reservationDate,
     resource,
@@ -22,7 +25,7 @@ const reservationPageSelector = createSelector(
 
     return {
       date: reservationDate,
-      id: resource.id,
+      id,
       isFetchingResource,
       resource,
       unit,

--- a/app/selectors/containers/reservationPageSelector.js
+++ b/app/selectors/containers/reservationPageSelector.js
@@ -2,22 +2,26 @@ import { createSelector } from 'reselect';
 
 import ActionTypes from 'constants/ActionTypes';
 import resourceSelector from 'selectors/resourceSelector';
+import reservationDateSelector from 'selectors/reservationDateSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
 const unitsSelector = (state) => state.data.units;
 
-export const resourcePageSelectors = createSelector(
+const reservationPageSelector = createSelector(
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
+  reservationDateSelector,
   resourceSelector,
   unitsSelector,
   (
     isFetchingResource,
+    reservationDate,
     resource,
     units
   ) => {
     const unit = units[resource.unit] || {};
 
     return {
+      date: reservationDate,
       id: resource.id,
       isFetchingResource,
       resource,
@@ -25,3 +29,5 @@ export const resourcePageSelectors = createSelector(
     };
   }
 );
+
+export default reservationPageSelector;

--- a/app/selectors/containers/resourcePageSelector.js
+++ b/app/selectors/containers/resourcePageSelector.js
@@ -4,13 +4,16 @@ import ActionTypes from 'constants/ActionTypes';
 import resourceSelector from 'selectors/resourceSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
+const idSelector = (state) => state.router.params.id;
 const unitsSelector = (state) => state.data.units;
 
 const resourcePageSelector = createSelector(
+  idSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   resourceSelector,
   unitsSelector,
   (
+    id,
     isFetchingResource,
     resource,
     units
@@ -18,7 +21,7 @@ const resourcePageSelector = createSelector(
     const unit = units[resource.unit] || {};
 
     return {
-      id: resource.id,
+      id,
       isFetchingResource,
       resource,
       unit,

--- a/app/selectors/containers/resourcePageSelector.js
+++ b/app/selectors/containers/resourcePageSelector.js
@@ -2,26 +2,22 @@ import { createSelector } from 'reselect';
 
 import ActionTypes from 'constants/ActionTypes';
 import resourceSelector from 'selectors/resourceSelector';
-import reservationDateSelector from 'selectors/reservationDateSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
 const unitsSelector = (state) => state.data.units;
 
-export const reservationPageSelectors = createSelector(
+const resourcePageSelector = createSelector(
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
-  reservationDateSelector,
   resourceSelector,
   unitsSelector,
   (
     isFetchingResource,
-    reservationDate,
     resource,
     units
   ) => {
     const unit = units[resource.unit] || {};
 
     return {
-      date: reservationDate,
       id: resource.id,
       isFetchingResource,
       resource,
@@ -29,3 +25,5 @@ export const reservationPageSelectors = createSelector(
     };
   }
 );
+
+export default resourcePageSelector;

--- a/app/selectors/containers/searchControlsSelector.js
+++ b/app/selectors/containers/searchControlsSelector.js
@@ -5,7 +5,7 @@ import purposeOptionsSelector from 'selectors/purposeOptionsSelector';
 import searchFiltersSelector from 'selectors/searchFiltersSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
-export const searchControlsSelectors = createSelector(
+const searchControlsSelector = createSelector(
   purposeOptionsSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.PURPOSES_GET_REQUEST),
   searchFiltersSelector,
@@ -21,3 +21,5 @@ export const searchControlsSelectors = createSelector(
     };
   }
 );
+
+export default searchControlsSelector;

--- a/app/selectors/containers/searchPageSelector.js
+++ b/app/selectors/containers/searchPageSelector.js
@@ -7,7 +7,7 @@ import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveS
 
 const unitsSelector = (state) => state.data.units;
 
-export const searchPageSelectors = createSelector(
+const searchPageSelector = createSelector(
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCES_GET_REQUEST),
   searchFiltersSelector,
   searchResultsSelector,
@@ -26,3 +26,5 @@ export const searchPageSelectors = createSelector(
     };
   }
 );
+
+export default searchPageSelector;

--- a/app/selectors/factories/__tests__/modalIsOpenSelectorFactory.spec.js
+++ b/app/selectors/factories/__tests__/modalIsOpenSelectorFactory.spec.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+
+import Immutable from 'seamless-immutable';
+
+import modalIsOpenSelectorFactory from 'selectors/factories/modalIsOpenSelectorFactory';
+
+function getState(openModals) {
+  return {
+    ui: Immutable({
+      modals: {
+        open: openModals,
+      },
+    }),
+  };
+}
+
+describe('Selector factory: modalIsOpenSelectorFactory', () => {
+  it('should return a function', () => {
+    expect(typeof modalIsOpenSelectorFactory()).to.equal('function');
+  });
+
+  describe('the returned function', () => {
+    const modalType = 'SOME_MODAL';
+
+    it('should return true if given modal is in open modals', () => {
+      const selector = modalIsOpenSelectorFactory(modalType);
+      const state = getState([modalType]);
+
+      expect(selector(state)).to.equal(true);
+    });
+
+    it('should return false if given modal is not in open modals', () => {
+      const selector = modalIsOpenSelectorFactory(modalType);
+      const state = getState([]);
+
+      expect(selector(state)).to.equal(false);
+    });
+  });
+});

--- a/app/selectors/factories/__tests__/requestIsActiveSelectorFactory.spec.js
+++ b/app/selectors/factories/__tests__/requestIsActiveSelectorFactory.spec.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+
+import Immutable from 'seamless-immutable';
+
+import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
+
+function getState(activeRequests) {
+  return {
+    api: Immutable({
+      activeRequests,
+    }),
+  };
+}
+
+describe('Selector factory: requestIsActiveSelectorFactory', () => {
+  it('should return a function', () => {
+    expect(typeof requestIsActiveSelectorFactory()).to.equal('function');
+  });
+
+  describe('the returned function', () => {
+    const requestActionType = 'SOME_GET_REQUEST';
+
+    it('should return true if given request is in activeRequests', () => {
+      const selector = requestIsActiveSelectorFactory(requestActionType);
+      const state = getState([requestActionType]);
+
+      expect(selector(state)).to.equal(true);
+    });
+
+    it('should return false if given request is not in open activeRequests', () => {
+      const selector = requestIsActiveSelectorFactory(requestActionType);
+      const state = getState([]);
+
+      expect(selector(state)).to.equal(false);
+    });
+  });
+});

--- a/app/selectors/factories/modalIsOpenSelectorFactory.js
+++ b/app/selectors/factories/modalIsOpenSelectorFactory.js
@@ -1,0 +1,15 @@
+import _ from 'lodash';
+import { createSelector } from 'reselect';
+
+const modalIsOpenSelectorFactory = (modalType) => {
+  const openModalsSelector = (state) => state.ui.modals.open;
+
+  return createSelector(
+    openModalsSelector,
+    (openModals) => {
+      return _.includes(openModals, modalType);
+    }
+  );
+};
+
+export default modalIsOpenSelectorFactory;

--- a/app/selectors/factories/requestIsActiveSelectorFactory.js
+++ b/app/selectors/factories/requestIsActiveSelectorFactory.js
@@ -1,0 +1,15 @@
+import _ from 'lodash';
+import { createSelector } from 'reselect';
+
+const requestIsActiveSelectorFactory = (requestActionType) => {
+  const activeRequestsSelector = (state) => state.api.activeRequests;
+
+  return createSelector(
+    activeRequestsSelector,
+    (activeRequests) => {
+      return _.includes(activeRequests, requestActionType);
+    }
+  );
+};
+
+export default requestIsActiveSelectorFactory;

--- a/app/selectors/purposeCategoriesSelector.js
+++ b/app/selectors/purposeCategoriesSelector.js
@@ -1,0 +1,15 @@
+import _ from 'lodash';
+import { createSelector } from 'reselect';
+
+const purposesSelector = (state) => state.data.purposes;
+
+export const purposeCategoriesSelector = createSelector(
+  purposesSelector,
+  (purposes) => {
+    const purposeCategories = _.groupBy(purposes, 'mainType');
+
+    return purposeCategories;
+  }
+);
+
+export default purposeCategoriesSelector;

--- a/app/selectors/purposeCategoryListSelectors.js
+++ b/app/selectors/purposeCategoryListSelectors.js
@@ -2,19 +2,18 @@ import _ from 'lodash';
 import { createSelector } from 'reselect';
 
 import types from 'constants/ActionTypes';
+import purposeCategoriesSelector from 'selectors/purposeCategoriesSelector';
 
 const activeRequestsSelector = (state) => state.api.activeRequests;
-const purposesSelector = (state) => state.data.purposes;
 
 export const purposeCategoryListSelectors = createSelector(
   activeRequestsSelector,
-  purposesSelector,
+  purposeCategoriesSelector,
   (
     activeRequests,
-    purposes
+    purposeCategories
   ) => {
     const isFetchingPurposes = _.includes(activeRequests, types.API.PURPOSES_GET_REQUEST);
-    const purposeCategories = _.groupBy(purposes, 'mainType');
 
     return {
       isFetchingPurposes,

--- a/app/selectors/purposeCategoryListSelectors.js
+++ b/app/selectors/purposeCategoryListSelectors.js
@@ -1,20 +1,16 @@
-import _ from 'lodash';
 import { createSelector } from 'reselect';
 
-import types from 'constants/ActionTypes';
+import ActionTypes from 'constants/ActionTypes';
 import purposeCategoriesSelector from 'selectors/purposeCategoriesSelector';
-
-const activeRequestsSelector = (state) => state.api.activeRequests;
+import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
 export const purposeCategoryListSelectors = createSelector(
-  activeRequestsSelector,
   purposeCategoriesSelector,
+  requestIsActiveSelectorFactory(ActionTypes.API.PURPOSES_GET_REQUEST),
   (
-    activeRequests,
-    purposeCategories
+    purposeCategories,
+    isFetchingPurposes
   ) => {
-    const isFetchingPurposes = _.includes(activeRequests, types.API.PURPOSES_GET_REQUEST);
-
     return {
       isFetchingPurposes,
       purposeCategories,

--- a/app/selectors/purposeOptionsSelector.js
+++ b/app/selectors/purposeOptionsSelector.js
@@ -1,0 +1,23 @@
+import _ from 'lodash';
+import { createSelector } from 'reselect';
+import Immutable from 'seamless-immutable';
+
+import { getName } from 'utils/DataUtils';
+
+const purposesSelector = (state) => state.data.purposes;
+
+const purposeOptionsSelector = createSelector(
+  purposesSelector,
+  (purposes) => {
+    const purposeOptions = Immutable(_.values(purposes).map(purpose => {
+      return {
+        value: purpose.id,
+        label: getName(purpose),
+      };
+    }));
+
+    return purposeOptions;
+  }
+);
+
+export default purposeOptionsSelector;

--- a/app/selectors/reservationDateSelector.js
+++ b/app/selectors/reservationDateSelector.js
@@ -1,0 +1,14 @@
+import { createSelector } from 'reselect';
+
+import { getDateString } from 'utils/TimeUtils';
+
+const dateSelector = (state) => state.ui.reservation.date;
+
+const reservationDateSelector = createSelector(
+  dateSelector,
+  (date) => {
+    return getDateString(date);
+  }
+);
+
+export default reservationDateSelector;

--- a/app/selectors/reservationFormSelectors.js
+++ b/app/selectors/reservationFormSelectors.js
@@ -4,13 +4,13 @@ import { createSelector } from 'reselect';
 import types from 'constants/ActionTypes';
 import reservationDateSelector from 'selectors/reservationDateSelector';
 import selectedReservationsSelector from 'selectors/selectedReservationsSelector';
+import modalIsOpenSelectorFactory from 'selectors/factories/modalIsOpenSelectorFactory';
 import { getOpeningHours } from 'utils/DataUtils';
 import { getTimeSlots } from 'utils/TimeUtils';
 import ModalTypes from 'constants/ModalTypes';
 
 const activeRequestsSelector = (state) => state.api.activeRequests;
 const idSelector = (state) => state.router.params.id;
-const openModalsSelector = (state) => state.ui.modals.open;
 const pendingReservationsCountSelector = (state) => state.api.pendingReservationsCount;
 const resourcesSelector = (state) => state.data.resources;
 const selectedSelector = (state) => state.ui.reservation.selected;
@@ -18,7 +18,7 @@ const selectedSelector = (state) => state.ui.reservation.selected;
 export const reservationFormSelectors = createSelector(
   activeRequestsSelector,
   idSelector,
-  openModalsSelector,
+  modalIsOpenSelectorFactory(ModalTypes.CONFIRM_RESERVATION),
   pendingReservationsCountSelector,
   reservationDateSelector,
   resourcesSelector,
@@ -27,14 +27,13 @@ export const reservationFormSelectors = createSelector(
   (
     activeRequests,
     id,
-    openModals,
+    confirmReservationModalIsOpen,
     pendingReservationsCount,
     reservationDate,
     resources,
     selected,
     selectedReservations
   ) => {
-    const confirmReservationModalIsOpen = _.includes(openModals, ModalTypes.CONFIRM_RESERVATION);
     const isFetchingResource = _.includes(activeRequests, types.API.RESOURCE_GET_REQUEST);
     const resource = resources[id] || {};
     const { closes, opens } = getOpeningHours(resource);

--- a/app/selectors/reservationFormSelectors.js
+++ b/app/selectors/reservationFormSelectors.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 
 import ActionTypes from 'constants/ActionTypes';
 import reservationDateSelector from 'selectors/reservationDateSelector';
+import resourceSelector from 'selectors/resourceSelector';
 import selectedReservationsSelector from 'selectors/selectedReservationsSelector';
 import modalIsOpenSelectorFactory from 'selectors/factories/modalIsOpenSelectorFactory';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
@@ -9,31 +10,26 @@ import { getOpeningHours } from 'utils/DataUtils';
 import { getTimeSlots } from 'utils/TimeUtils';
 import ModalTypes from 'constants/ModalTypes';
 
-const idSelector = (state) => state.router.params.id;
 const pendingReservationsCountSelector = (state) => state.api.pendingReservationsCount;
-const resourcesSelector = (state) => state.data.resources;
 const selectedSelector = (state) => state.ui.reservation.selected;
 
 export const reservationFormSelectors = createSelector(
-  idSelector,
   modalIsOpenSelectorFactory(ModalTypes.CONFIRM_RESERVATION),
   pendingReservationsCountSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   reservationDateSelector,
-  resourcesSelector,
+  resourceSelector,
   selectedSelector,
   selectedReservationsSelector,
   (
-    id,
     confirmReservationModalIsOpen,
     pendingReservationsCount,
     isFetchingResource,
     reservationDate,
-    resources,
+    resource,
     selected,
     selectedReservations
   ) => {
-    const resource = resources[id] || {};
     const { closes, opens } = getOpeningHours(resource);
     const period = resource.minPeriod ? resource.minPeriod : undefined;
     const reservations = resource.reservations || undefined;
@@ -42,7 +38,7 @@ export const reservationFormSelectors = createSelector(
     return {
       confirmReservationModalIsOpen,
       date: reservationDate,
-      id,
+      id: resource.id,
       isFetchingResource,
       isMakingReservations: Boolean(pendingReservationsCount),
       selected,

--- a/app/selectors/reservationFormSelectors.js
+++ b/app/selectors/reservationFormSelectors.js
@@ -1,12 +1,9 @@
 import _ from 'lodash';
 import { createSelector } from 'reselect';
-import Immutable from 'seamless-immutable';
 
 import types from 'constants/ActionTypes';
-import {
-  combineReservations,
-  getOpeningHours,
-} from 'utils/DataUtils';
+import selectedReservationsSelector from 'selectors/selectedReservationsSelector';
+import { getOpeningHours } from 'utils/DataUtils';
 import { getDateString, getTimeSlots } from 'utils/TimeUtils';
 import ModalTypes from 'constants/ModalTypes';
 
@@ -26,6 +23,7 @@ export const reservationFormSelectors = createSelector(
   pendingReservationsCountSelector,
   resourcesSelector,
   selectedSelector,
+  selectedReservationsSelector,
   (
     activeRequests,
     date,
@@ -33,7 +31,8 @@ export const reservationFormSelectors = createSelector(
     openModals,
     pendingReservationsCount,
     resources,
-    selected
+    selected,
+    selectedReservations
   ) => {
     const confirmReservationModalIsOpen = _.includes(openModals, ModalTypes.CONFIRM_RESERVATION);
     const isFetchingResource = _.includes(activeRequests, types.API.RESOURCE_GET_REQUEST);
@@ -42,15 +41,6 @@ export const reservationFormSelectors = createSelector(
     const period = resource.minPeriod ? resource.minPeriod : undefined;
     const reservations = resource.reservations || undefined;
     const timeSlots = getTimeSlots(opens, closes, period, reservations);
-
-    const selectedSlots = selected.map(current => {
-      return {
-        begin: current.split('/')[0],
-        end: current.split('/')[1],
-        resource: id,
-      };
-    });
-    const selectedReservations = Immutable(combineReservations(selectedSlots));
 
     return {
       confirmReservationModalIsOpen,

--- a/app/selectors/reservationFormSelectors.js
+++ b/app/selectors/reservationFormSelectors.js
@@ -2,13 +2,13 @@ import _ from 'lodash';
 import { createSelector } from 'reselect';
 
 import types from 'constants/ActionTypes';
+import reservationDateSelector from 'selectors/reservationDateSelector';
 import selectedReservationsSelector from 'selectors/selectedReservationsSelector';
 import { getOpeningHours } from 'utils/DataUtils';
-import { getDateString, getTimeSlots } from 'utils/TimeUtils';
+import { getTimeSlots } from 'utils/TimeUtils';
 import ModalTypes from 'constants/ModalTypes';
 
 const activeRequestsSelector = (state) => state.api.activeRequests;
-const dateSelector = (state) => state.ui.reservation.date;
 const idSelector = (state) => state.router.params.id;
 const openModalsSelector = (state) => state.ui.modals.open;
 const pendingReservationsCountSelector = (state) => state.api.pendingReservationsCount;
@@ -17,19 +17,19 @@ const selectedSelector = (state) => state.ui.reservation.selected;
 
 export const reservationFormSelectors = createSelector(
   activeRequestsSelector,
-  dateSelector,
   idSelector,
   openModalsSelector,
   pendingReservationsCountSelector,
+  reservationDateSelector,
   resourcesSelector,
   selectedSelector,
   selectedReservationsSelector,
   (
     activeRequests,
-    date,
     id,
     openModals,
     pendingReservationsCount,
+    reservationDate,
     resources,
     selected,
     selectedReservations
@@ -44,7 +44,7 @@ export const reservationFormSelectors = createSelector(
 
     return {
       confirmReservationModalIsOpen,
-      date: getDateString(date),
+      date: reservationDate,
       id,
       isFetchingResource,
       isMakingReservations: Boolean(pendingReservationsCount),

--- a/app/selectors/reservationFormSelectors.js
+++ b/app/selectors/reservationFormSelectors.js
@@ -1,40 +1,38 @@
-import _ from 'lodash';
 import { createSelector } from 'reselect';
 
-import types from 'constants/ActionTypes';
+import ActionTypes from 'constants/ActionTypes';
 import reservationDateSelector from 'selectors/reservationDateSelector';
 import selectedReservationsSelector from 'selectors/selectedReservationsSelector';
 import modalIsOpenSelectorFactory from 'selectors/factories/modalIsOpenSelectorFactory';
+import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 import { getOpeningHours } from 'utils/DataUtils';
 import { getTimeSlots } from 'utils/TimeUtils';
 import ModalTypes from 'constants/ModalTypes';
 
-const activeRequestsSelector = (state) => state.api.activeRequests;
 const idSelector = (state) => state.router.params.id;
 const pendingReservationsCountSelector = (state) => state.api.pendingReservationsCount;
 const resourcesSelector = (state) => state.data.resources;
 const selectedSelector = (state) => state.ui.reservation.selected;
 
 export const reservationFormSelectors = createSelector(
-  activeRequestsSelector,
   idSelector,
   modalIsOpenSelectorFactory(ModalTypes.CONFIRM_RESERVATION),
   pendingReservationsCountSelector,
+  requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   reservationDateSelector,
   resourcesSelector,
   selectedSelector,
   selectedReservationsSelector,
   (
-    activeRequests,
     id,
     confirmReservationModalIsOpen,
     pendingReservationsCount,
+    isFetchingResource,
     reservationDate,
     resources,
     selected,
     selectedReservations
   ) => {
-    const isFetchingResource = _.includes(activeRequests, types.API.RESOURCE_GET_REQUEST);
     const resource = resources[id] || {};
     const { closes, opens } = getOpeningHours(resource);
     const period = resource.minPeriod ? resource.minPeriod : undefined;

--- a/app/selectors/reservationPageSelectors.js
+++ b/app/selectors/reservationPageSelectors.js
@@ -1,32 +1,28 @@
 import { createSelector } from 'reselect';
 
 import ActionTypes from 'constants/ActionTypes';
+import resourceSelector from 'selectors/resourceSelector';
 import reservationDateSelector from 'selectors/reservationDateSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
-const idSelector = (state) => state.router.params.id;
-const resourcesSelector = (state) => state.data.resources;
 const unitsSelector = (state) => state.data.units;
 
 export const reservationPageSelectors = createSelector(
-  idSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   reservationDateSelector,
-  resourcesSelector,
+  resourceSelector,
   unitsSelector,
   (
-    id,
     isFetchingResource,
     reservationDate,
-    resources,
+    resource,
     units
   ) => {
-    const resource = resources[id] || {};
     const unit = units[resource.unit] || {};
 
     return {
       date: reservationDate,
-      id,
+      id: resource.id,
       isFetchingResource,
       resource,
       unit,

--- a/app/selectors/reservationPageSelectors.js
+++ b/app/selectors/reservationPageSelectors.js
@@ -1,28 +1,26 @@
-import _ from 'lodash';
 import { createSelector } from 'reselect';
 
-import types from 'constants/ActionTypes';
+import ActionTypes from 'constants/ActionTypes';
 import reservationDateSelector from 'selectors/reservationDateSelector';
+import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
-const activeRequestsSelector = (state) => state.api.activeRequests;
 const idSelector = (state) => state.router.params.id;
 const resourcesSelector = (state) => state.data.resources;
 const unitsSelector = (state) => state.data.units;
 
 export const reservationPageSelectors = createSelector(
-  activeRequestsSelector,
   idSelector,
+  requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   reservationDateSelector,
   resourcesSelector,
   unitsSelector,
   (
-    activeRequests,
     id,
+    isFetchingResource,
     reservationDate,
     resources,
     units
   ) => {
-    const isFetchingResource = _.includes(activeRequests, types.API.RESOURCE_GET_REQUEST);
     const resource = resources[id] || {};
     const unit = units[resource.unit] || {};
 

--- a/app/selectors/reservationPageSelectors.js
+++ b/app/selectors/reservationPageSelectors.js
@@ -2,24 +2,23 @@ import _ from 'lodash';
 import { createSelector } from 'reselect';
 
 import types from 'constants/ActionTypes';
-import { getDateString } from 'utils/TimeUtils';
+import reservationDateSelector from 'selectors/reservationDateSelector';
 
 const activeRequestsSelector = (state) => state.api.activeRequests;
-const dateSelector = (state) => state.ui.reservation.date;
 const idSelector = (state) => state.router.params.id;
 const resourcesSelector = (state) => state.data.resources;
 const unitsSelector = (state) => state.data.units;
 
 export const reservationPageSelectors = createSelector(
   activeRequestsSelector,
-  dateSelector,
   idSelector,
+  reservationDateSelector,
   resourcesSelector,
   unitsSelector,
   (
     activeRequests,
-    date,
     id,
+    reservationDate,
     resources,
     units
   ) => {
@@ -28,7 +27,7 @@ export const reservationPageSelectors = createSelector(
     const unit = units[resource.unit] || {};
 
     return {
-      date: getDateString(date),
+      date: reservationDate,
       id,
       isFetchingResource,
       resource,

--- a/app/selectors/resourcePageSelectors.js
+++ b/app/selectors/resourcePageSelectors.js
@@ -1,28 +1,24 @@
 import { createSelector } from 'reselect';
 
 import ActionTypes from 'constants/ActionTypes';
+import resourceSelector from 'selectors/resourceSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
-const idSelector = (state) => state.router.params.id;
-const resourcesSelector = (state) => state.data.resources;
 const unitsSelector = (state) => state.data.units;
 
 export const resourcePageSelectors = createSelector(
-  idSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
-  resourcesSelector,
+  resourceSelector,
   unitsSelector,
   (
-    id,
     isFetchingResource,
-    resources,
+    resource,
     units
   ) => {
-    const resource = resources[id] || {};
     const unit = units[resource.unit] || {};
 
     return {
-      id,
+      id: resource.id,
       isFetchingResource,
       resource,
       unit,

--- a/app/selectors/resourcePageSelectors.js
+++ b/app/selectors/resourcePageSelectors.js
@@ -1,25 +1,23 @@
-import _ from 'lodash';
 import { createSelector } from 'reselect';
 
-import types from 'constants/ActionTypes';
+import ActionTypes from 'constants/ActionTypes';
+import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
-const activeRequestsSelector = (state) => state.api.activeRequests;
 const idSelector = (state) => state.router.params.id;
 const resourcesSelector = (state) => state.data.resources;
 const unitsSelector = (state) => state.data.units;
 
 export const resourcePageSelectors = createSelector(
-  activeRequestsSelector,
   idSelector,
+  requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   resourcesSelector,
   unitsSelector,
   (
-    activeRequests,
     id,
+    isFetchingResource,
     resources,
     units
   ) => {
-    const isFetchingResource = _.includes(activeRequests, types.API.RESOURCE_GET_REQUEST);
     const resource = resources[id] || {};
     const unit = units[resource.unit] || {};
 

--- a/app/selectors/resourceSelector.js
+++ b/app/selectors/resourceSelector.js
@@ -1,0 +1,14 @@
+import { createSelector } from 'reselect';
+
+const idSelector = (state) => state.router.params.id;
+const resourcesSelector = (state) => state.data.resources;
+
+const resourceSelector = createSelector(
+  idSelector,
+  resourcesSelector,
+  (id, resources) => {
+    return resources[id] || {};
+  }
+);
+
+export default resourceSelector;

--- a/app/selectors/searchControlsSelectors.js
+++ b/app/selectors/searchControlsSelectors.js
@@ -1,23 +1,19 @@
-import _ from 'lodash';
 import { createSelector } from 'reselect';
 
-import types from 'constants/ActionTypes';
+import ActionTypes from 'constants/ActionTypes';
 import purposeOptionsSelector from 'selectors/purposeOptionsSelector';
 import searchFiltersSelector from 'selectors/searchFiltersSelector';
-
-const activeRequestsSelector = (state) => state.api.activeRequests;
+import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
 export const searchControlsSelectors = createSelector(
-  activeRequestsSelector,
   purposeOptionsSelector,
+  requestIsActiveSelectorFactory(ActionTypes.API.PURPOSES_GET_REQUEST),
   searchFiltersSelector,
   (
-    activeRequests,
     purposeOptions,
+    isFetchingPurposes,
     searchFilters
   ) => {
-    const isFetchingPurposes = _.includes(activeRequests, types.API.PURPOSES_GET_REQUEST);
-
     return {
       isFetchingPurposes,
       filters: searchFilters,

--- a/app/selectors/searchControlsSelectors.js
+++ b/app/selectors/searchControlsSelectors.js
@@ -3,21 +3,20 @@ import { createSelector } from 'reselect';
 import Immutable from 'seamless-immutable';
 
 import types from 'constants/ActionTypes';
+import searchFiltersSelector from 'selectors/searchFiltersSelector';
 import { getName } from 'utils/DataUtils';
-import { getDateString } from 'utils/TimeUtils';
 
 const activeRequestsSelector = (state) => state.api.activeRequests;
-const filtersSelector = (state) => state.ui.search.filters;
 const purposesSelector = (state) => state.data.purposes;
 
 export const searchControlsSelectors = createSelector(
   activeRequestsSelector,
-  filtersSelector,
   purposesSelector,
+  searchFiltersSelector,
   (
     activeRequests,
-    filters,
-    purposes
+    purposes,
+    searchFilters
   ) => {
     const isFetchingPurposes = _.includes(activeRequests, types.API.PURPOSES_GET_REQUEST);
     const purposeOptions = Immutable(_.values(purposes).map(purpose => {
@@ -29,7 +28,7 @@ export const searchControlsSelectors = createSelector(
 
     return {
       isFetchingPurposes,
-      filters: Object.assign({}, filters, { date: getDateString(filters.date) }),
+      filters: searchFilters,
       purposeOptions,
     };
   }

--- a/app/selectors/searchControlsSelectors.js
+++ b/app/selectors/searchControlsSelectors.js
@@ -1,30 +1,22 @@
 import _ from 'lodash';
 import { createSelector } from 'reselect';
-import Immutable from 'seamless-immutable';
 
 import types from 'constants/ActionTypes';
+import purposeOptionsSelector from 'selectors/purposeOptionsSelector';
 import searchFiltersSelector from 'selectors/searchFiltersSelector';
-import { getName } from 'utils/DataUtils';
 
 const activeRequestsSelector = (state) => state.api.activeRequests;
-const purposesSelector = (state) => state.data.purposes;
 
 export const searchControlsSelectors = createSelector(
   activeRequestsSelector,
-  purposesSelector,
+  purposeOptionsSelector,
   searchFiltersSelector,
   (
     activeRequests,
-    purposes,
+    purposeOptions,
     searchFilters
   ) => {
     const isFetchingPurposes = _.includes(activeRequests, types.API.PURPOSES_GET_REQUEST);
-    const purposeOptions = Immutable(_.values(purposes).map(purpose => {
-      return {
-        value: purpose.id,
-        label: getName(purpose),
-      };
-    }));
 
     return {
       isFetchingPurposes,

--- a/app/selectors/searchFiltersSelector.js
+++ b/app/selectors/searchFiltersSelector.js
@@ -1,0 +1,16 @@
+import { createSelector } from 'reselect';
+
+import { getDateString } from 'utils/TimeUtils';
+
+const filtersSelector = (state) => state.ui.search.filters;
+
+const searchFiltersSelector = createSelector(
+  filtersSelector,
+  (filters) => {
+    const searchFilters = Object.assign({}, filters, { date: getDateString(filters.date) });
+
+    return searchFilters;
+  }
+);
+
+export default searchFiltersSelector;

--- a/app/selectors/searchPageSelectors.js
+++ b/app/selectors/searchPageSelectors.js
@@ -3,35 +3,28 @@ import { createSelector } from 'reselect';
 
 import types from 'constants/ActionTypes';
 import searchFiltersSelector from 'selectors/searchFiltersSelector';
+import searchResultsSelector from 'selectors/searchResultsSelector';
 
 const activeRequestsSelector = (state) => state.api.activeRequests;
-const resourcesSelector = (state) => state.data.resources;
-const searchResultsSelector = (state) => state.ui.search.results;
 const unitsSelector = (state) => state.data.units;
 
 export const searchPageSelectors = createSelector(
   activeRequestsSelector,
-  resourcesSelector,
   searchFiltersSelector,
   searchResultsSelector,
   unitsSelector,
   (
     activeRequests,
-    resources,
     searchFilters,
     searchResults,
     units
   ) => {
     const isFetchingSearchResults = _.includes(activeRequests, types.API.RESOURCES_GET_REQUEST);
-    const results = _.sortBy(
-      searchResults.map(resourceId => resources[resourceId]),
-      (result) => result.name.fi
-    );
 
     return {
       filters: searchFilters,
       isFetchingSearchResults,
-      results,
+      results: searchResults,
       units,
     };
   }

--- a/app/selectors/searchPageSelectors.js
+++ b/app/selectors/searchPageSelectors.js
@@ -2,24 +2,23 @@ import _ from 'lodash';
 import { createSelector } from 'reselect';
 
 import types from 'constants/ActionTypes';
-import { getDateString } from 'utils/TimeUtils';
+import searchFiltersSelector from 'selectors/searchFiltersSelector';
 
 const activeRequestsSelector = (state) => state.api.activeRequests;
-const filtersSelector = (state) => state.ui.search.filters;
 const resourcesSelector = (state) => state.data.resources;
 const searchResultsSelector = (state) => state.ui.search.results;
 const unitsSelector = (state) => state.data.units;
 
 export const searchPageSelectors = createSelector(
   activeRequestsSelector,
-  filtersSelector,
   resourcesSelector,
+  searchFiltersSelector,
   searchResultsSelector,
   unitsSelector,
   (
     activeRequests,
-    filters,
     resources,
+    searchFilters,
     searchResults,
     units
   ) => {
@@ -30,7 +29,7 @@ export const searchPageSelectors = createSelector(
     );
 
     return {
-      filters: Object.assign({}, filters, { date: getDateString(filters.date) }),
+      filters: searchFilters,
       isFetchingSearchResults,
       results,
       units,

--- a/app/selectors/searchPageSelectors.js
+++ b/app/selectors/searchPageSelectors.js
@@ -1,26 +1,23 @@
-import _ from 'lodash';
 import { createSelector } from 'reselect';
 
-import types from 'constants/ActionTypes';
+import ActionTypes from 'constants/ActionTypes';
 import searchFiltersSelector from 'selectors/searchFiltersSelector';
 import searchResultsSelector from 'selectors/searchResultsSelector';
+import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
-const activeRequestsSelector = (state) => state.api.activeRequests;
 const unitsSelector = (state) => state.data.units;
 
 export const searchPageSelectors = createSelector(
-  activeRequestsSelector,
+  requestIsActiveSelectorFactory(ActionTypes.API.RESOURCES_GET_REQUEST),
   searchFiltersSelector,
   searchResultsSelector,
   unitsSelector,
   (
-    activeRequests,
+    isFetchingSearchResults,
     searchFilters,
     searchResults,
     units
   ) => {
-    const isFetchingSearchResults = _.includes(activeRequests, types.API.RESOURCES_GET_REQUEST);
-
     return {
       filters: searchFilters,
       isFetchingSearchResults,

--- a/app/selectors/searchResultsSelector.js
+++ b/app/selectors/searchResultsSelector.js
@@ -1,0 +1,20 @@
+import _ from 'lodash';
+import { createSelector } from 'reselect';
+
+const resourcesSelector = (state) => state.data.resources;
+const resultsSelector = (state) => state.ui.search.results;
+
+const searchResultsSelector = createSelector(
+  resourcesSelector,
+  resultsSelector,
+  (resources, results) => {
+    const searchResults = _.sortBy(
+      results.map(resourceId => resources[resourceId]),
+      (result) => result.name.fi
+    );
+
+    return searchResults;
+  }
+);
+
+export default searchResultsSelector;

--- a/app/selectors/selectedReservationsSelector.js
+++ b/app/selectors/selectedReservationsSelector.js
@@ -1,0 +1,27 @@
+import { createSelector } from 'reselect';
+import Immutable from 'seamless-immutable';
+
+import { combineReservations } from 'utils/DataUtils';
+
+const idSelector = (state) => state.router.params.id;
+const selectedSelector = (state) => state.ui.reservation.selected;
+
+const selectedReservationsSelector = createSelector(
+  idSelector,
+  selectedSelector,
+  (id, selected) => {
+    const selectedSlots = selected.map(current => {
+      const dateTimes = current.split('/');
+      return {
+        begin: dateTimes[0],
+        end: dateTimes[1],
+        resource: id,
+      };
+    });
+    const selectedReservations = Immutable(combineReservations(selectedSlots));
+
+    return selectedReservations;
+  }
+);
+
+export default selectedReservationsSelector;

--- a/app/utils/TestUtils.js
+++ b/app/utils/TestUtils.js
@@ -1,0 +1,9 @@
+import rootReducer from 'reducers/index';
+
+export default {
+  getInitialState,
+};
+
+function getInitialState() {
+  return rootReducer(undefined, {});
+}


### PR DESCRIPTION
This PR does some major refactoring on the selectors:
- Split individual selectors to own files.
- Organize selectors to folders.
- Makes container selectors mostly just use the individual selectors.
- Adds more tests on the individual selectors.

Makes selectors:
- easier to test
- easier to make more efficient
- more DRY

Closes #81.