### PR TITLE
Update seamless-immutable to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "redux-localstorage-filter": "^0.1.1",
     "redux-router": "^1.0.0-beta3",
     "reselect": "^2.0.0",
-    "seamless-immutable": "^4.0.0"
+    "seamless-immutable": "^4.0.2"
   },
   "devDependencies": {
     "autoprefixer": "^6.0.3",


### PR DESCRIPTION
Updates seamless-immutable to version 4.0.2
This update gives us automatic errors on development
whenever we try to mutate an immutable object.
Makes doing mutations by accident a lot harder.