### PR TITLE
Feature/95 reservation page small improvements

### DIFF
--- a/app/components/common/TimeRange.js
+++ b/app/components/common/TimeRange.js
@@ -4,15 +4,29 @@ import React, { Component, PropTypes } from 'react';
 
 class TimeRange extends Component {
   render() {
-    const { begin, end } = this.props;
+    const {
+      begin,
+      dateFormat,
+      end,
+      lineBreaks,
+      timeFormat,
+    } = this.props;
     const beginMoment = moment(begin);
     const endMoment = moment(end);
-    const timeString = `${beginMoment.format('LLLL')} \u2013 ${endMoment.format('H:mm')}`;
+    const dateString = beginMoment.format(dateFormat);
+    const timeString = `klo ${beginMoment.format(timeFormat)} \u2013 ${endMoment.format(timeFormat)}`;
     const ISORangeString = `${begin}/${end}`;
 
     return (
       <time dateTime={ISORangeString}>
-        {_.capitalize(timeString)}
+        {lineBreaks ? (
+          <div>
+            <div>{_.capitalize(dateString)}</div>
+            <div>{timeString}</div>
+          </div>
+        ) : (
+          `${_.capitalize(dateString)} ${timeString}`
+        )}
       </time>
     );
   }
@@ -20,7 +34,16 @@ class TimeRange extends Component {
 
 TimeRange.propTypes = {
   begin: PropTypes.string.isRequired,
+  dateFormat: PropTypes.string.isRequired,
   end: PropTypes.string.isRequired,
+  lineBreaks: PropTypes.bool.isRequired,
+  timeFormat: PropTypes.string.isRequired,
+};
+
+TimeRange.defaultProps = {
+  dateFormat: 'dddd, Do MMMM[ta]',
+  lineBreaks: false,
+  timeFormat: 'H:mm',
 };
 
 export default TimeRange;

--- a/app/components/common/__tests__/TimeRange.spec.js
+++ b/app/components/common/__tests__/TimeRange.spec.js
@@ -9,7 +9,9 @@ import TimeRange from 'components/common/TimeRange';
 describe('Component: common/TimeRange', () => {
   const props = {
     begin: '2015-10-11T12:00:00Z',
+    dateFormat: 'ddd, Do MMMM[ta]',
     end: '2015-10-11T14:00:00Z',
+    timeFormat: 'H:mm',
   };
 
   const tree = sd.shallowRender(<TimeRange {...props} />);
@@ -27,19 +29,25 @@ describe('Component: common/TimeRange', () => {
     expect(timeTree.props.dateTime).to.equal(expected);
   });
 
-  describe('the humanized time range', () => {
-    const humanized = tree.subTree('time').props.children;
+  describe('the datetime range string', () => {
+    const rangeString = tree.subTree('time').props.children;
 
-    it('should display the begin datetime in humanized format', () => {
-      const expected = moment(props.begin).format('LLLL');
+    it('should display the date in given dateFormat', () => {
+      const expected = moment(props.begin).format(props.dateFormat);
 
-      expect(humanized).to.contain(expected);
+      expect(rangeString).to.contain(expected);
     });
 
-    it('should display just the time from the end', () => {
-      const expected = `\u2013 ${moment(props.end).format('H:mm')}`;
+    it('should display the begin time in given timeFormat', () => {
+      const expected = moment(props.begin).format(props.timeFormat);
 
-      expect(humanized).to.contain(expected);
+      expect(rangeString).to.contain(expected);
+    });
+
+    it('should display the end time in given time format', () => {
+      const expected = moment(props.end).format(props.timeFormat);
+
+      expect(rangeString).to.contain(expected);
     });
   });
 });

--- a/app/components/reservation/ConfirmReservationModal.js
+++ b/app/components/reservation/ConfirmReservationModal.js
@@ -38,7 +38,7 @@ class ConfirmReservationModal extends Component {
 
     return (
       <div>
-        <p>Oletko varma että haluat tehdä seuraavat varaukset?</p>
+        <p><strong>Oletko varma että haluat tehdä seuraavat varaukset?</strong></p>
         <ul>
           {_.map(selectedReservations, this.renderReservation)}
         </ul>

--- a/app/components/reservation/DeleteModal.js
+++ b/app/components/reservation/DeleteModal.js
@@ -43,11 +43,11 @@ class DeleteModal extends Component {
         show={show}
       >
         <Modal.Header closeButton>
-          <Modal.Title>Poistamisen varmistus</Modal.Title>
+          <Modal.Title>Poistamisen vahvistus</Modal.Title>
         </Modal.Header>
 
         <Modal.Body>
-          <p>Oletko varma että haluat poistaa seuraavat varaukset?</p>
+          <p><strong>Oletko varma että haluat poistaa seuraavat varaukset?</strong></p>
           <ul>
             {_.map(reservationsToDelete, this.renderReservation)}
           </ul>

--- a/app/components/reservation/ReservationsTableRow.js
+++ b/app/components/reservation/ReservationsTableRow.js
@@ -74,8 +74,8 @@ class ReservationsTableRow extends Component {
           <Link to={`/resources/${resource.id}`}>
             {getName(resource)}
           </Link>
+          <div>{getName(unit)}</div>
         </td>
-        <td>{getName(unit)}</td>
         <td>
           <TimeRange begin={reservation.begin} end={reservation.end} />
         </td>

--- a/app/components/reservation/ReservationsTableRow.js
+++ b/app/components/reservation/ReservationsTableRow.js
@@ -77,11 +77,16 @@ class ReservationsTableRow extends Component {
           <div>{getName(unit)}</div>
         </td>
         <td>
-          <TimeRange
-            begin={reservation.begin}
-            end={reservation.end}
-            lineBreaks
-          />
+          <Link
+            to={`/resources/${resource.id}/reservation`}
+            query={{ date: reservation.begin.split('T')[0] }}
+          >
+            <TimeRange
+              begin={reservation.begin}
+              end={reservation.end}
+              lineBreaks
+            />
+        </Link>
         </td>
         <td>
           {this.renderButtons()}

--- a/app/components/reservation/ReservationsTableRow.js
+++ b/app/components/reservation/ReservationsTableRow.js
@@ -77,7 +77,11 @@ class ReservationsTableRow extends Component {
           <div>{getName(unit)}</div>
         </td>
         <td>
-          <TimeRange begin={reservation.begin} end={reservation.end} />
+          <TimeRange
+            begin={reservation.begin}
+            end={reservation.end}
+            lineBreaks
+          />
         </td>
         <td>
           {this.renderButtons()}

--- a/app/components/reservation/__tests__/DeleteModal.spec.js
+++ b/app/components/reservation/__tests__/DeleteModal.spec.js
@@ -45,10 +45,10 @@ describe('Component: reservation/DeleteModal', () => {
       expect(modalTitleTrees.length).to.equal(1);
     });
 
-    it('the ModalTitle should display text "Poistamisen varmistus"', () => {
+    it('the ModalTitle should display text "Poistamisen vahvistus"', () => {
       const modalTitleTree = tree.subTree('ModalTitle');
 
-      expect(modalTitleTree.props.children).to.equal('Poistamisen varmistus');
+      expect(modalTitleTree.props.children).to.equal('Poistamisen vahvistus');
     });
   });
 

--- a/app/components/reservation/__tests__/ReservationsTableRow.spec.js
+++ b/app/components/reservation/__tests__/ReservationsTableRow.spec.js
@@ -60,6 +60,16 @@ describe('Component: reservation/ReservationsTableRow', () => {
       describe('the second table cell', () => {
         const tdTree = tdTrees[1];
 
+        it('should have a Link with correct props', () => {
+          const linkTree = tdTree.subTree('Link');
+
+          expect(linkTree).to.be.ok;
+          expect(linkTree.props.to).to.equal(`/resources/${props.resource.id}/reservation`);
+          expect(linkTree.props.query).to.deep.equal(
+            { date: props.reservation.begin.split('T')[0] }
+          );
+        });
+
         it('should contain a TimeRange component with correct begin and end times', () => {
           const timeRangeTree = tdTree.subTree('TimeRange');
 

--- a/app/components/reservation/__tests__/ReservationsTableRow.spec.js
+++ b/app/components/reservation/__tests__/ReservationsTableRow.spec.js
@@ -31,8 +31,8 @@ describe('Component: reservation/ReservationsTableRow', () => {
     describe('table cells', () => {
       const tdTrees = tree.everySubTree('td');
 
-      it('should render 4 table cells', () => {
-        expect(tdTrees).to.have.length(4);
+      it('should render 3 table cells', () => {
+        expect(tdTrees).to.have.length(3);
       });
 
       describe('the first table cell', () => {
@@ -49,20 +49,16 @@ describe('Component: reservation/ReservationsTableRow', () => {
 
           expect(tdTree.toString()).to.contain(expected);
         });
-      });
-
-      describe('the second table cell', () => {
-        const tdTree = tdTrees[1];
 
         it('should display the name of the given unit in props', () => {
           const expected = props.unit.name.fi;
 
-          expect(tdTree.text()).to.equal(expected);
+          expect(tdTree.text()).to.contain(expected);
         });
       });
 
-      describe('the third table cell', () => {
-        const tdTree = tdTrees[2];
+      describe('the second table cell', () => {
+        const tdTree = tdTrees[1];
 
         it('should contain a TimeRange component with correct begin and end times', () => {
           const timeRangeTree = tdTree.subTree('TimeRange');
@@ -72,8 +68,8 @@ describe('Component: reservation/ReservationsTableRow', () => {
         });
       });
 
-      describe('the fourth table cell', () => {
-        const tdTree = tdTrees[3];
+      describe('the third table cell', () => {
+        const tdTree = tdTrees[2];
         const buttonTrees = tdTree.everySubTree('Button');
 
         it('should contain two buttons', () => {

--- a/app/containers/ReservationsTable.js
+++ b/app/containers/ReservationsTable.js
@@ -85,7 +85,6 @@ export class UnconnectedReservationsTable extends Component {
               <thead>
                 <tr>
                   <th>Tila</th>
-                  <th>Sijainti</th>
                   <th>Aika</th>
                   <th>Toiminnot</th>
                 </tr>

--- a/app/containers/__tests__/ReservationsTable.spec.js
+++ b/app/containers/__tests__/ReservationsTable.spec.js
@@ -75,24 +75,20 @@ describe('Component: reservation/ReservationsTable', () => {
         thTrees = tree.everySubTree('th');
       });
 
-      it('should render 4 th elements', () => {
-        expect(thTrees.length).to.equal(4);
+      it('should render 3 th elements', () => {
+        expect(thTrees.length).to.equal(3);
       });
 
       it('first th element should contain text "Tila"', () => {
         expect(thTrees[0].text()).to.equal('Tila');
       });
 
-      it('second th element should contain text "Sijainti"', () => {
-        expect(thTrees[1].text()).to.equal('Sijainti');
+      it('second th element should contain text "Aika"', () => {
+        expect(thTrees[1].text()).to.equal('Aika');
       });
 
-      it('third th element should contain text "Aika"', () => {
-        expect(thTrees[2].text()).to.equal('Aika');
-      });
-
-      it('fourth th element should contain text "Toiminnot"', () => {
-        expect(thTrees[3].text()).to.equal('Toiminnot');
+      it('third th element should contain text "Toiminnot"', () => {
+        expect(thTrees[2].text()).to.equal('Toiminnot');
       });
     });
 


### PR DESCRIPTION
This PR: 
- Makes the my reservations table more suitable for mobile use by moving the unit to same table cell as the resource and splitting the time to two lines.
- Adds a link from my reservations to the reservation page with the correct reservation date.
- Improves TimeRange component formatting options.

Closes #95.
