### PR TITLE
Make my reservations edit links use correct date

### DIFF
--- a/app/components/reservation/ReservationsTableRow.js
+++ b/app/components/reservation/ReservationsTableRow.js
@@ -33,7 +33,11 @@ class ReservationsTableRow extends Component {
     } = this.props;
 
     selectReservationToEdit(reservation);
-    pushState(null, `/resources/${reservation.resource}/reservation`);
+    pushState(
+      null,
+      `/resources/${reservation.resource}/reservation`,
+      { date: reservation.begin.split('T')[0] }
+    );
   }
 
   renderButtons() {


### PR DESCRIPTION
Make the edit buttons link to correct reservation date on my reservations page.
Refs #90 and #95.