### PR TITLE
Remove unneeded babel-presets from packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
     "babel-eslint": "^4.1.3",
     "babel-loader": "^5.3.2",
     "babel-plugin-react-transform": "^1.1.1",
-    "babel-preset-es2015": "^6.0.15",
-    "babel-preset-react": "^6.0.15",
     "css-loader": "^0.21.0",
     "eslint": "^1.8.0",
     "eslint-config-airbnb": "^0.1.0",


### PR DESCRIPTION
This PR removes babel-preset packages that are needed only after we update to babel version 6.