### PR TITLE
Disable devtools on development on default

### DIFF
--- a/config/webpack.development.js
+++ b/config/webpack.development.js
@@ -63,7 +63,7 @@ module.exports = merge(common, {
   plugins: [
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('development'),
-      __DEVTOOLS__: true,
+      __DEVTOOLS__: false,
     }),
     new HtmlWebpackPlugin({
       favicon: './app/assets/images/favicon.ico',


### PR DESCRIPTION
The opening new window is a bit annoying. Devtools
are now disabled by default before we get the new version
of them on the project.