### PR TITLE
Improve resource reserve button mobile styles

### DIFF
--- a/app/assets/styles/app.less
+++ b/app/assets/styles/app.less
@@ -17,6 +17,9 @@
 // Layout
 @import './layout';
 
+// Pages
+@import './resource-page';
+
 // Components
 @import './loader';
 @import './notifications';

--- a/app/assets/styles/resource-page.less
+++ b/app/assets/styles/resource-page.less
@@ -1,0 +1,21 @@
+.resource-page {
+  position: relative;
+
+  h1 {
+    @media (min-width: @screen-sm-min) {
+      padding-right: 140px;
+    }
+  }
+
+  .reserve-button {
+    width: 100%;
+    margin-bottom: 20px;
+
+    @media (min-width: @screen-sm-min) {
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: auto;
+    }
+  }
+}

--- a/app/containers/ResourcePage.js
+++ b/app/containers/ResourcePage.js
@@ -42,20 +42,20 @@ export class UnconnectedResourcePage extends Component {
     return (
       <DocumentTitle title={`${resourceName} - Respa`}>
         <Loader loaded={!_.isEmpty(resource)}>
-          <div>
-            <LinkContainer to={`/resources/${id}/reservation`}>
-              <Button
-                bsSize="large"
-                bsStyle="primary"
-                style={{ float: 'right' }}
-              >
-                Varaa tila
-              </Button>
-            </LinkContainer>
+          <div className="resource-page">
             <ResourceHeader
               address={getAddressWithName(unit)}
               name={resourceName}
             />
+            <LinkContainer to={`/resources/${id}/reservation`}>
+              <Button
+                bsSize="large"
+                bsStyle="primary"
+                className="reserve-button"
+              >
+                Varaa tila
+              </Button>
+            </LinkContainer>
             <ResourceDetails
               capacityString={getPeopleCapacityString(resource.peopleCapacity)}
               description={getDescription(resource)}


### PR DESCRIPTION
This PR locates the resource page reserve button under the location text and makes it expand to the whole width of the screen on mobile screen sizes.

Closes #117.