### PR TITLE
Feature/119 navbar improvements

### DIFF
--- a/app/components/layout/Navbar.js
+++ b/app/components/layout/Navbar.js
@@ -1,6 +1,7 @@
 import Radium from 'radium';
 import React, { Component, PropTypes } from 'react';
 import {
+  CollapsibleNav,
   Glyphicon,
   MenuItem,
   Navbar as RBNavbar,
@@ -41,8 +42,6 @@ class Navbar extends Component {
   }
 
   render() {
-    const RadiumNav = Radium(Nav);
-
     return (
       <RBNavbar inverse toggleNavKey={0}>
         <NavBrand>
@@ -55,16 +54,18 @@ class Navbar extends Component {
             Respa
           </Link>
         </NavBrand>
-        <RadiumNav left style={styles.searchNav}>
-          <LinkContainer to="/search">
-            <NavItem>
-              <Glyphicon glyph="search" />
-            </NavItem>
-          </LinkContainer>
-        </RadiumNav>
-        <Nav eventKey={0} right>
-          {this.renderUserNav()}
-        </Nav>
+        <CollapsibleNav eventKey={0}>
+          <Nav navbar>
+            <LinkContainer to="/search">
+              <NavItem>
+                <Glyphicon glyph="search" />
+              </NavItem>
+            </LinkContainer>
+          </Nav>
+          <Nav navbar eventKey={0} right>
+            {this.renderUserNav()}
+          </Nav>
+        </CollapsibleNav>
       </RBNavbar>
     );
   }

--- a/app/components/layout/Navbar.js
+++ b/app/components/layout/Navbar.js
@@ -58,7 +58,7 @@ class Navbar extends Component {
           <Nav navbar>
             <LinkContainer to="/search">
               <NavItem>
-                <Glyphicon glyph="search" />
+                <Glyphicon glyph="search" /> Haku
               </NavItem>
             </LinkContainer>
           </Nav>

--- a/app/components/layout/Navbar.styles.js
+++ b/app/components/layout/Navbar.styles.js
@@ -1,12 +1,5 @@
-const brandWidth = 200;
-
 export default {
   navBrand: {
-    position: 'absolute',
-    left: '50%',
-    width: brandWidth,
-    textAlign: 'center',
-    marginLeft: -(brandWidth / 2),
     color: '#fff',
   },
 
@@ -16,13 +9,5 @@ export default {
     height: 40,
     marginTop: -8,
     marginRight: 10,
-  },
-
-  searchNav: {
-    '@media (max-width: 767px)': {
-      position: 'absolute',
-      top: 9,
-      margin: 0,
-    },
   },
 };


### PR DESCRIPTION
This PR:
- Moves brand to the left.
- Adds "Haku" beside the search icon.
- Moves the search link under the collapsible navigation on mobile screen sizes to keep the navbar
clear.

Closes #119.