### PR TITLE
Feature/improve session handling

### DIFF
--- a/app/reducers/__tests__/authReducer.spec.js
+++ b/app/reducers/__tests__/authReducer.spec.js
@@ -39,5 +39,71 @@ describe('Reducer: authReducer', () => {
         expect(nextState.token).to.equal(null);
       });
     });
+
+    describe('API.RESERVATION_DELETE_ERROR', () => {
+      const reservationDeleteError = createAction(types.API.RESERVATION_DELETE_ERROR);
+
+      it('should set state to initialState if error status is 401', () => {
+        const action = reservationDeleteError({ status: 401 });
+        const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
+        const nextState = authReducer(initialState, action);
+        const expectedState = Immutable({ token: null, userId: null });
+
+        expect(nextState).to.deep.equal(expectedState);
+      });
+
+      it('should not affect state if error status is not 401', () => {
+        const action = reservationDeleteError({ status: 403 });
+        const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
+        const nextState = authReducer(initialState, action);
+        const expectedState = initialState;
+
+        expect(nextState).to.deep.equal(expectedState);
+      });
+    });
+
+    describe('API.RESERVATION_POST_ERROR', () => {
+      const reservationPostError = createAction(types.API.RESERVATION_POST_ERROR);
+
+      it('should set state to initialState if error status is 401', () => {
+        const action = reservationPostError({ status: 401 });
+        const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
+        const nextState = authReducer(initialState, action);
+        const expectedState = Immutable({ token: null, userId: null });
+
+        expect(nextState).to.deep.equal(expectedState);
+      });
+
+      it('should not affect state if error status is not 401', () => {
+        const action = reservationPostError({ status: 403 });
+        const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
+        const nextState = authReducer(initialState, action);
+        const expectedState = initialState;
+
+        expect(nextState).to.deep.equal(expectedState);
+      });
+    });
+
+    describe('API.RESERVATION_PUT_ERROR', () => {
+      const reservationPutError = createAction(types.API.RESERVATION_PUT_ERROR);
+
+      it('should set state to initialState if error status is 401', () => {
+        const action = reservationPutError({ status: 401 });
+        const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
+        const nextState = authReducer(initialState, action);
+        const expectedState = Immutable({ token: null, userId: null });
+
+        expect(nextState).to.deep.equal(expectedState);
+      });
+
+      it('should not affect state if error status is not 401', () => {
+        const action = reservationPutError({ status: 403 });
+        const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
+        const nextState = authReducer(initialState, action);
+        const expectedState = initialState;
+
+        expect(nextState).to.deep.equal(expectedState);
+      });
+    });
   });
 });

--- a/app/reducers/authReducer.js
+++ b/app/reducers/authReducer.js
@@ -13,6 +13,14 @@ function authReducer(state = initialState, action) {
   case types.API.LOGOUT:
     return initialState;
 
+  case types.API.RESERVATION_DELETE_ERROR:
+  case types.API.RESERVATION_PUT_ERROR:
+  case types.API.RESERVATION_POST_ERROR:
+    if (action.payload.status === 401) {
+      return initialState;
+    }
+    return state;
+
   default:
     return state;
   }

--- a/app/reducers/notificationsReducer.js
+++ b/app/reducers/notificationsReducer.js
@@ -41,7 +41,7 @@ function notificationsReducer(state = initialState, action) {
   case types.API.RESERVATION_DELETE_ERROR:
     message = 'Varauksen poistaminen epäonnistui. Yritä hetken kuluttua uudelleen.';
     if (action.payload.status === 401) {
-      message = 'Sinulla ei ole oikeutta poistaa varausta.';
+      message = 'Kirjaudu sisään poistaaksesi varauksen.';
     }
 
     notification = {
@@ -61,7 +61,7 @@ function notificationsReducer(state = initialState, action) {
   case types.API.RESERVATION_POST_ERROR:
     message = 'Varauksen tekeminen epäonnistui.';
     if (action.payload.status === 401) {
-      message = 'Sinulla ei ole oikeutta tehdä varausta.';
+      message = 'Kirjaudu sisään tehdäksesi varauksen.';
     }
 
     notification = {
@@ -81,7 +81,7 @@ function notificationsReducer(state = initialState, action) {
   case types.API.RESERVATION_PUT_ERROR:
     message = 'Varauksen muuttaminen epäonnistui.';
     if (action.payload.status === 401) {
-      message = 'Sinulla ei ole oikeutta muuttaa varausta.';
+      message = 'Kirjaudu sisään muuttaaksesi varausta.';
     }
 
     notification = {

--- a/server/main.js
+++ b/server/main.js
@@ -54,7 +54,7 @@ app.use(cookieParser());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieSession({
   secret: process.env.SESSION_SECRET,
-  cookie: { maxAge: 60 * 60000 },
+  maxAge: 60 * 60000,
 }));
 
 // Initialize Passport and restore authentication state, if any, from the

--- a/server/render.js
+++ b/server/render.js
@@ -7,11 +7,9 @@ import Html from './Html';
 function render(req, res) {
   const user = req.user;
   let initialState = {};
-  if (user && user.id) {
-    const token = user.token;
-    delete user.token;
+  if (user && user.id && user.token) {
     initialState = {
-      auth: { userId: user.id, token },
+      auth: { userId: user.id, token: user.token },
       data: {
         users: {
           [user.id]: user,


### PR DESCRIPTION
This PR:
- Fixes the cookie session maxAge setting so the session expires after one hour (The time authorization token should be valid on the backend.
- Requires both token and userId to be found on the session to pass initial data to the client. This prevents cases where user appears to be logged in even though they don't have a token.
- Logs users out on 401 errors (at this point these mean that the token has expired).