### PR TITLE
Hotfix/133 dates in fixtures

### DIFF
--- a/app/components/search/__tests__/SearchResults.spec.js
+++ b/app/components/search/__tests__/SearchResults.spec.js
@@ -88,6 +88,7 @@ describe('Component: search/SearchResults', () => {
 
   describe('without results', () => {
     const props = {
+      date: '2015-10-10',
       isFetching: false,
       results: [],
       units: {},

--- a/app/fixtures/Reservation.js
+++ b/app/fixtures/Reservation.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { Factory } from 'rosie';
 
-const BASE_DATE = new Date(2015, 10, 10);
+const BASE_DATE = moment().add(2, 'days');
 
 const Reservation = new Factory()
   .sequence('index')

--- a/app/fixtures/TimeSlot.js
+++ b/app/fixtures/TimeSlot.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { Factory } from 'rosie';
 
-const BASE_DATE = new Date(2015, 10, 10);
+const BASE_DATE = moment().add(2, 'days');
 
 const TimeSlot = new Factory()
   .sequence('index')


### PR DESCRIPTION
This PR makes sure fixture dates are always in the future and also adds a missing date prop to SearchResults spec.

Closes #133.