### PR TITLE
Feature/118 reservation page improvements

### DIFF
--- a/app/assets/styles/time-slots.less
+++ b/app/assets/styles/time-slots.less
@@ -1,4 +1,20 @@
 .time-slots {
+  thead tr {
+    border-bottom: 1px solid @gray;
+  }
+
+  tbody tr {
+    border-bottom: 1px solid @gray-lighter;
+
+    &:hover {
+      cursor: pointer;
+    }
+    &.disabled:hover {
+      cursor: not-allowed;
+      background-color: inherit;
+    }
+  }
+
   .editing, .editing td {
     background-color: rgba(0, 114, 198, 0.2);
   }

--- a/app/assets/styles/time-slots.less
+++ b/app/assets/styles/time-slots.less
@@ -10,21 +10,34 @@
       cursor: pointer;
     }
 
-    &.disabled:hover {
-      cursor: not-allowed;
-      background-color: inherit;
+    .checkbox-cell {
+      text-align: center;
+      width: 70px;
+      color: @gray-dark;
+      font-size: 20px;
+      padding: 0;
+
+      span {
+        top: 7px;
+      }
     }
-  }
 
-  .checkbox-cell {
-    text-align: center;
-    width: 70px;
-    color: @gray-dark;
-    font-size: 20px;
-    padding: 0;
+    // Past styles
+    // -----------
+    &.past {
+      .checkbox-cell,
+      .time-cell {
+        color: @gray-light;
+      }
+    }
 
-    span {
-      top: 7px;
+    // Disabled styles
+    // ---------------
+    &.disabled {
+      &:hover {
+        cursor: not-allowed;
+        background-color: inherit;
+      }
     }
   }
 

--- a/app/assets/styles/time-slots.less
+++ b/app/assets/styles/time-slots.less
@@ -9,9 +9,22 @@
     &:hover {
       cursor: pointer;
     }
+
     &.disabled:hover {
       cursor: not-allowed;
       background-color: inherit;
+    }
+  }
+
+  .checkbox-cell {
+    text-align: center;
+    width: 70px;
+    color: @gray-dark;
+    font-size: 20px;
+    padding: 0;
+
+    span {
+      top: 7px;
     }
   }
 

--- a/app/assets/styles/time-slots.less
+++ b/app/assets/styles/time-slots.less
@@ -22,6 +22,34 @@
       }
     }
 
+    // Reserved styles
+    // ---------------
+    &.reserved {
+      .checkbox-cell {
+        color: @brand-danger;
+      }
+    }
+
+    // Editing styles
+    // --------------
+    &.editing {
+      .checkbox-cell {
+        color: @brand-info;
+      }
+    }
+
+    // Selected styles
+    // ---------------
+    &.selected {
+      td {
+        background-color: rgba(0, 156, 61, 0.25);
+      }
+
+      .checkbox-cell {
+        color: @brand-success;
+      }
+    }
+
     // Past styles
     // -----------
     &.past {
@@ -39,9 +67,5 @@
         background-color: inherit;
       }
     }
-  }
-
-  .editing, .editing td {
-    background-color: rgba(0, 114, 198, 0.2);
   }
 }

--- a/app/components/reservation/ReservationsTableRow.js
+++ b/app/components/reservation/ReservationsTableRow.js
@@ -29,10 +29,11 @@ class ReservationsTableRow extends Component {
     const {
       pushState,
       reservation,
+      resource,
       selectReservationToEdit,
     } = this.props;
 
-    selectReservationToEdit(reservation);
+    selectReservationToEdit({ reservation, minPeriod: resource.minPeriod });
     pushState(
       null,
       `/resources/${reservation.resource}/reservation`,

--- a/app/components/reservation/ReservationsTableRow.js
+++ b/app/components/reservation/ReservationsTableRow.js
@@ -37,7 +37,10 @@ class ReservationsTableRow extends Component {
     pushState(
       null,
       `/resources/${reservation.resource}/reservation`,
-      { date: reservation.begin.split('T')[0] }
+      {
+        date: reservation.begin.split('T')[0],
+        time: reservation.begin,
+      }
     );
   }
 
@@ -84,7 +87,10 @@ class ReservationsTableRow extends Component {
         <td>
           <Link
             to={`/resources/${resource.id}/reservation`}
-            query={{ date: reservation.begin.split('T')[0] }}
+            query={{
+              date: reservation.begin.split('T')[0],
+              time: reservation.begin,
+            }}
           >
             <TimeRange
               begin={reservation.begin}

--- a/app/components/reservation/TimeSlot.js
+++ b/app/components/reservation/TimeSlot.js
@@ -5,7 +5,7 @@ import { Glyphicon, Label } from 'react-bootstrap';
 
 class TimeSlot extends Component {
   render() {
-    const { onChange, selected, slot } = this.props;
+    const { onClick, selected, slot } = this.props;
     const isPast = moment(slot.end) < moment();
     const disabled = !slot.editing && (slot.reserved || isPast);
     const checked = selected || (slot.reserved && !slot.editing);
@@ -25,7 +25,7 @@ class TimeSlot extends Component {
           reserved: slot.reserved,
           selected,
         })}
-        onClick={() => !disabled && onChange(slot.asISOString)}
+        onClick={() => !disabled && onClick(slot.asISOString)}
       >
         <td className="checkbox-cell">
           <Glyphicon glyph={checked ? 'check' : 'unchecked'} />
@@ -46,7 +46,7 @@ class TimeSlot extends Component {
 }
 
 TimeSlot.propTypes = {
-  onChange: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
   selected: PropTypes.bool.isRequired,
   slot: PropTypes.object.isRequired,
 };

--- a/app/components/reservation/TimeSlot.js
+++ b/app/components/reservation/TimeSlot.js
@@ -10,10 +10,17 @@ class TimeSlot extends Component {
     const disabled = !slot.editing && (slot.reserved || isPast);
     const checked = selected || (slot.reserved && !slot.editing);
     let labelBsStyle;
+    let labelText;
     if (isPast) {
       labelBsStyle = 'default';
     } else {
       labelBsStyle = slot.reserved ? 'danger' : 'success';
+    }
+    if (slot.editing) {
+      labelBsStyle = 'info';
+      labelText = 'Muokataan';
+    } else {
+      labelText = slot.reserved ? 'Varattu' : 'Vapaa';
     }
 
     return (
@@ -37,7 +44,7 @@ class TimeSlot extends Component {
         </td>
         <td>
           <Label bsStyle={labelBsStyle}>
-            {slot.reserved ? 'Varattu' : 'Vapaa'}
+            {labelText}
           </Label>
         </td>
       </tr>

--- a/app/components/reservation/TimeSlot.js
+++ b/app/components/reservation/TimeSlot.js
@@ -12,10 +12,12 @@ class TimeSlot extends Component {
     return (
       <tr
         className={classNames({
+          disabled,
           editing: slot.editing,
           reserved: slot.reserved,
-          selected: selected,
+          selected,
         })}
+        onClick={() => !disabled && onChange(slot.asISOString)}
       >
         <td style={{ textAlign: 'center' }}>
           <input

--- a/app/components/reservation/TimeSlot.js
+++ b/app/components/reservation/TimeSlot.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import moment from 'moment';
 import React, { Component, PropTypes } from 'react';
-import { Label } from 'react-bootstrap';
+import { Glyphicon, Label } from 'react-bootstrap';
 
 class TimeSlot extends Component {
   render() {
@@ -19,13 +19,8 @@ class TimeSlot extends Component {
         })}
         onClick={() => !disabled && onChange(slot.asISOString)}
       >
-        <td style={{ textAlign: 'center' }}>
-          <input
-            checked={checked}
-            disabled={disabled}
-            onChange={() => onChange(slot.asISOString)}
-            type="checkbox"
-          />
+        <td className="checkbox-cell">
+          <Glyphicon glyph={checked ? 'check' : 'unchecked'} />
         </td>
         <td>
           <time dateTime={slot.asISOString}>

--- a/app/components/reservation/TimeSlot.js
+++ b/app/components/reservation/TimeSlot.js
@@ -1,9 +1,19 @@
 import classNames from 'classnames';
 import moment from 'moment';
 import React, { Component, PropTypes } from 'react';
+import { findDOMNode } from 'react-dom';
 import { Glyphicon, Label } from 'react-bootstrap';
 
 class TimeSlot extends Component {
+  componentDidMount() {
+    if (this.props.scrollTo) {
+      const bodyOffsetTop = document.body.getBoundingClientRect().top;
+      const slotOffsetTop = findDOMNode(this).getBoundingClientRect().top;
+      const scrollTo = slotOffsetTop - bodyOffsetTop;
+      window.scrollTo(0, scrollTo);
+    }
+  }
+
   render() {
     const { onClick, selected, slot } = this.props;
     const isPast = moment(slot.end) < moment();
@@ -54,6 +64,7 @@ class TimeSlot extends Component {
 
 TimeSlot.propTypes = {
   onClick: PropTypes.func.isRequired,
+  scrollTo: PropTypes.bool,
   selected: PropTypes.bool.isRequired,
   slot: PropTypes.object.isRequired,
 };

--- a/app/components/reservation/TimeSlot.js
+++ b/app/components/reservation/TimeSlot.js
@@ -6,14 +6,22 @@ import { Glyphicon, Label } from 'react-bootstrap';
 class TimeSlot extends Component {
   render() {
     const { onChange, selected, slot } = this.props;
-    const disabled = !slot.editing && (slot.reserved || moment(slot.end) < moment());
+    const isPast = moment(slot.end) < moment();
+    const disabled = !slot.editing && (slot.reserved || isPast);
     const checked = selected || (slot.reserved && !slot.editing);
+    let labelBsStyle;
+    if (isPast) {
+      labelBsStyle = 'default';
+    } else {
+      labelBsStyle = slot.reserved ? 'danger' : 'success';
+    }
 
     return (
       <tr
         className={classNames({
           disabled,
           editing: slot.editing,
+          'past': isPast,
           reserved: slot.reserved,
           selected,
         })}
@@ -22,13 +30,13 @@ class TimeSlot extends Component {
         <td className="checkbox-cell">
           <Glyphicon glyph={checked ? 'check' : 'unchecked'} />
         </td>
-        <td>
+        <td className="time-cell">
           <time dateTime={slot.asISOString}>
             {slot.asString}
           </time>
         </td>
         <td>
-          <Label bsStyle={slot.reserved ? 'danger' : 'success'}>
+          <Label bsStyle={labelBsStyle}>
             {slot.reserved ? 'Varattu' : 'Vapaa'}
           </Label>
         </td>

--- a/app/components/reservation/TimeSlots.js
+++ b/app/components/reservation/TimeSlots.js
@@ -30,7 +30,10 @@ class TimeSlots extends Component {
     return (
       <Loader loaded={!isFetching}>
         {slots.length ? (
-          <Table className="time-slots" striped>
+          <Table
+            className="time-slots"
+            hover
+          >
             <thead>
               <tr>
                 <th />

--- a/app/components/reservation/TimeSlots.js
+++ b/app/components/reservation/TimeSlots.js
@@ -12,12 +12,14 @@ class TimeSlots extends Component {
   }
 
   renderTimeSlot(slot) {
-    const { onClick, selected } = this.props;
+    const { onClick, selected, time } = this.props;
+    const scrollTo = time && time === slot.start;
 
     return (
       <TimeSlot
         key={slot.start}
         onClick={onClick}
+        scrollTo={scrollTo}
         selected={_.includes(selected, slot.asISOString)}
         slot={slot}
       />
@@ -58,6 +60,7 @@ TimeSlots.propTypes = {
   onClick: PropTypes.func.isRequired,
   selected: PropTypes.array.isRequired,
   slots: PropTypes.array.isRequired,
+  time: PropTypes.string,
 };
 
 export default TimeSlots;

--- a/app/components/reservation/TimeSlots.js
+++ b/app/components/reservation/TimeSlots.js
@@ -12,12 +12,12 @@ class TimeSlots extends Component {
   }
 
   renderTimeSlot(slot) {
-    const { onChange, selected } = this.props;
+    const { onClick, selected } = this.props;
 
     return (
       <TimeSlot
         key={slot.start}
-        onChange={onChange}
+        onClick={onClick}
         selected={_.includes(selected, slot.asISOString)}
         slot={slot}
       />
@@ -55,7 +55,7 @@ class TimeSlots extends Component {
 
 TimeSlots.propTypes = {
   isFetching: PropTypes.bool.isRequired,
-  onChange: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
   selected: PropTypes.array.isRequired,
   slots: PropTypes.array.isRequired,
 };

--- a/app/components/reservation/__tests__/ReservationsTableRow.spec.js
+++ b/app/components/reservation/__tests__/ReservationsTableRow.spec.js
@@ -66,7 +66,10 @@ describe('Component: reservation/ReservationsTableRow', () => {
           expect(linkTree).to.be.ok;
           expect(linkTree.props.to).to.equal(`/resources/${props.resource.id}/reservation`);
           expect(linkTree.props.query).to.deep.equal(
-            { date: props.reservation.begin.split('T')[0] }
+            {
+              date: props.reservation.begin.split('T')[0],
+              time: props.reservation.begin,
+            }
           );
         });
 

--- a/app/components/reservation/__tests__/ReservationsTableRow.spec.js
+++ b/app/components/reservation/__tests__/ReservationsTableRow.spec.js
@@ -96,12 +96,12 @@ describe('Component: reservation/ReservationsTableRow', () => {
           describe('clicking the button', () => {
             buttonTree.props.onClick();
 
-            it('should call props.selectReservationToEdit with this reservation', () => {
+            it('should call props.selectReservationToEdit with reservation and minPeriod', () => {
               expect(props.selectReservationToEdit.callCount).to.equal(1);
               expect(
                 props.selectReservationToEdit.lastCall.args[0]
               ).to.deep.equal(
-                props.reservation
+                { reservation: props.reservation, minPeriod: props.resource.minPeriod }
               );
             });
 

--- a/app/components/reservation/__tests__/TimeSlot.spec.js
+++ b/app/components/reservation/__tests__/TimeSlot.spec.js
@@ -10,7 +10,7 @@ import TimeSlotFixture from 'fixtures/TimeSlot';
 
 describe('Component: reservation/TimeSlot', () => {
   const props = {
-    onChange: simple.stub(),
+    onClick: simple.stub(),
     selected: false,
     slot: Immutable(TimeSlotFixture.build()),
   };
@@ -21,10 +21,10 @@ describe('Component: reservation/TimeSlot', () => {
     expect(vdom.type).to.equal('tr');
   });
 
-  it('clicking the table row should call props.onChange with correct arguments', () => {
+  it('clicking the table row should call props.onClick with correct arguments', () => {
     tree.props.onClick();
 
-    expect(props.onChange.callCount).to.equal(1);
+    expect(props.onClick.callCount).to.equal(1);
   });
 
   describe('table cells', () => {
@@ -84,7 +84,7 @@ describe('Component: reservation/TimeSlot', () => {
 
       describe('when the slot is reserved', () => {
         const reservedProps = {
-          onChange: simple.stub(),
+          onClick: simple.stub(),
           selected: false,
           slot: Immutable(TimeSlotFixture.build({ reserved: true })),
         };

--- a/app/components/reservation/__tests__/TimeSlot.spec.js
+++ b/app/components/reservation/__tests__/TimeSlot.spec.js
@@ -21,6 +21,12 @@ describe('Component: reservation/TimeSlot', () => {
     expect(vdom.type).to.equal('tr');
   });
 
+  it('clicking the table row should call props.onChange with correct arguments', () => {
+    tree.props.onClick();
+
+    expect(props.onChange.callCount).to.equal(1);
+  });
+
   describe('table cells', () => {
     const tdTrees = tree.everySubTree('td');
 
@@ -30,20 +36,14 @@ describe('Component: reservation/TimeSlot', () => {
 
     describe('the first table cell', () => {
       const tdTree = tdTrees[0];
-      const inputTree = tdTree.subTree('input');
+      const glyphiconTree = tdTree.subTree('Glyphicon');
 
-      it('should render a checkbox', () => {
-        expect(inputTree.props.type).to.equal('checkbox');
+      it('should render a checkbox icon', () => {
+        expect(glyphiconTree).to.be.ok;
       });
 
       it('should not be checked if the slot is available', () => {
-        expect(inputTree.props.checked).to.equal(false);
-      });
-
-      it('checking the checkbox should call props.onChange with correct arguments', () => {
-        inputTree.props.onChange();
-
-        expect(props.onChange.callCount).to.equal(1);
+        expect(glyphiconTree.props.glyph).to.equal('unchecked');
       });
     });
 

--- a/app/components/reservation/__tests__/TimeSlots.spec.js
+++ b/app/components/reservation/__tests__/TimeSlots.spec.js
@@ -16,7 +16,7 @@ describe('Component: reservation/TimeSlots', () => {
     ];
     const props = {
       isFetching: false,
-      onChange: simple.stub(),
+      onClick: simple.stub(),
       selected: [timeSlots[0].asISOString],
       slots: Immutable(timeSlots),
     };
@@ -69,7 +69,7 @@ describe('Component: reservation/TimeSlots', () => {
 
       it('should pass correct props to TimeSlots', () => {
         timeSlotTrees.forEach((timeSlotTree, index) => {
-          expect(timeSlotTree.props.onChange).to.equal(props.onChange);
+          expect(timeSlotTree.props.onClick).to.equal(props.onClick);
           expect(timeSlotTree.props.slot).to.deep.equal(props.slots[index]);
         });
       });
@@ -84,7 +84,7 @@ describe('Component: reservation/TimeSlots', () => {
   describe('without timeslots', () => {
     const props = {
       isFetching: false,
-      onChange: simple.stub(),
+      onClick: simple.stub(),
       selected: [],
       slots: [],
     };

--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -98,6 +98,7 @@ export class UnconnectedReservationForm extends Component {
       reservationsToEdit,
       selected,
       selectedReservations,
+      time,
       timeSlots,
     } = this.props;
     const isEditing = Boolean(reservationsToEdit.length);
@@ -120,6 +121,7 @@ export class UnconnectedReservationForm extends Component {
           onClick={actions.toggleTimeSlot}
           selected={selected}
           slots={timeSlots}
+          time={time}
         />
         <ReservationFormControls
           disabled={!selected.length || isMakingReservations}
@@ -152,6 +154,7 @@ UnconnectedReservationForm.propTypes = {
   reservationsToEdit: PropTypes.array.isRequired,
   selected: PropTypes.array.isRequired,
   selectedReservations: PropTypes.array.isRequired,
+  time: PropTypes.string,
   timeSlots: PropTypes.array.isRequired,
 };
 

--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -117,7 +117,7 @@ export class UnconnectedReservationForm extends Component {
         />
         <TimeSlots
           isFetching={isFetchingResource}
-          onChange={actions.toggleTimeSlot}
+          onClick={actions.toggleTimeSlot}
           selected={selected}
           slots={timeSlots}
         />

--- a/app/containers/__tests__/ReservationForm.spec.js
+++ b/app/containers/__tests__/ReservationForm.spec.js
@@ -104,7 +104,7 @@ describe('Container: ReservationForm', () => {
         const actualProps = timeSlotsTrees[0].props;
 
         expect(actualProps.isFetching).to.equal(props.isFetchingResource);
-        expect(actualProps.onChange).to.deep.equal(props.actions.toggleTimeSlot);
+        expect(actualProps.onClick).to.deep.equal(props.actions.toggleTimeSlot);
         expect(actualProps.selected).to.deep.equal(props.selected);
         expect(actualProps.slots).to.deep.equal(props.timeSlots);
       });

--- a/app/reducers/reservationReducer.js
+++ b/app/reducers/reservationReducer.js
@@ -3,6 +3,7 @@ import Immutable from 'seamless-immutable';
 
 import types from 'constants/ActionTypes';
 import ModalTypes from 'constants/ModalTypes';
+import { getTimeSlots } from 'utils/TimeUtils';
 
 const initialState = Immutable({
   selected: [],
@@ -11,11 +12,14 @@ const initialState = Immutable({
 });
 
 function selectReservationToEdit(state, action) {
-  const reservation = action.payload;
-  const date = reservation.begin.split('T')[0];
+  const { minPeriod, reservation } = action.payload;
+  const selected = _.map(
+    getTimeSlots(reservation.begin, reservation.end, minPeriod),
+    (slot) => slot.asISOString
+  );
 
   return state.merge({
-    date,
+    selected: [...state.selected, ...selected],
     toEdit: [...state.toEdit, reservation],
   });
 }

--- a/app/selectors/__tests__/timeSelector.spec.js
+++ b/app/selectors/__tests__/timeSelector.spec.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+
+import timeSelector from 'selectors/timeSelector';
+
+function getState(time) {
+  return {
+    router: {
+      location: {
+        query: {
+          time,
+        },
+      },
+    },
+  };
+}
+
+describe('Selector: timeSelector', () => {
+  it('should return the time ISOString in utc time if time is defined', () => {
+    const time = '2015-11-12T09:00:00+02:00';
+    const expected = '2015-11-12T07:00:00.000Z';
+    const state = getState(time);
+    const actual = timeSelector(state);
+
+    expect(actual).to.equal(expected);
+  });
+
+  it('should return undefined if time is not defined', () => {
+    const state = getState();
+    const actual = timeSelector(state);
+
+    expect(actual).to.equal(undefined);
+  });
+});

--- a/app/selectors/containers/__tests__/reservationFormSelector.spec.js
+++ b/app/selectors/containers/__tests__/reservationFormSelector.spec.js
@@ -21,6 +21,7 @@ function getState(resource, resourceId) {
       location: {
         query: {
           date: '2015-10-10',
+          time: '2015-10-10T12:00:00+03:00',
         },
       },
       params: {
@@ -109,6 +110,14 @@ describe('Selector: reservationFormSelector', () => {
 
     expect(selected.selectedReservations).to.exist;
   });
+
+  it('should return time', () => {
+    const state = getState(resource);
+    const selected = reservationFormSelector(state);
+
+    expect(selected.time).to.exist;
+  });
+
 
   describe('timeSlots', () => {
     it('should use resource properties to calculate correct time slots', () => {

--- a/app/selectors/containers/reservationFormSelector.js
+++ b/app/selectors/containers/reservationFormSelector.js
@@ -3,6 +3,7 @@ import { createSelector } from 'reselect';
 import ActionTypes from 'constants/ActionTypes';
 import dateSelector from 'selectors/dateSelector';
 import resourceSelector from 'selectors/resourceSelector';
+import timeSelector from 'selectors/timeSelector';
 import selectedReservationsSelector from 'selectors/selectedReservationsSelector';
 import modalIsOpenSelectorFactory from 'selectors/factories/modalIsOpenSelectorFactory';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
@@ -23,6 +24,7 @@ const reservationFormSelector = createSelector(
   resourceSelector,
   selectedSelector,
   selectedReservationsSelector,
+  timeSelector,
   toEditSelector,
   (
     id,
@@ -33,6 +35,7 @@ const reservationFormSelector = createSelector(
     resource,
     selected,
     selectedReservations,
+    time,
     reservationsToEdit
   ) => {
     const { closes, opens } = getOpeningHours(resource);
@@ -49,6 +52,7 @@ const reservationFormSelector = createSelector(
       reservationsToEdit,
       selected,
       selectedReservations,
+      time,
       timeSlots,
     };
   }

--- a/app/selectors/timeSelector.js
+++ b/app/selectors/timeSelector.js
@@ -1,0 +1,11 @@
+import moment from 'moment';
+
+const timeSelector = (state) => {
+  const time = state.router.location.query.time;
+  if (time) {
+    return moment.utc(time).toISOString();
+  }
+  return time;
+};
+
+export default timeSelector;


### PR DESCRIPTION
This PR:
- Make the whole reservation row clickable.
- Shows old reservations rows in gray.
- Makes checkboxes bigger.
- Add styles for selected and reserved rows.
- Scrolls to correct position when arriving from my reservations page.
- Makes edited reservations selected by default.

Closes #118.