### PR TITLE
Feature/87 reservations for logged in users

### DIFF
--- a/app/assets/styles/time-slots.less
+++ b/app/assets/styles/time-slots.less
@@ -62,6 +62,10 @@
     // Disabled styles
     // ---------------
     &.disabled {
+      .checkbox-cell {
+        color: @gray-light;
+      }
+
       &:hover {
         cursor: not-allowed;
         background-color: inherit;

--- a/app/components/reservation/TimeSlot.js
+++ b/app/components/reservation/TimeSlot.js
@@ -14,9 +14,9 @@ class TimeSlot extends Component {
   }
 
   render() {
-    const { onClick, selected, slot } = this.props;
+    const { isLoggedIn, onClick, selected, slot } = this.props;
     const isPast = moment(slot.end) < moment();
-    const disabled = !slot.editing && (slot.reserved || isPast);
+    const disabled = !isLoggedIn || !slot.editing && (slot.reserved || isPast);
     const checked = selected || (slot.reserved && !slot.editing);
     let labelBsStyle;
     let labelText;
@@ -62,6 +62,7 @@ class TimeSlot extends Component {
 }
 
 TimeSlot.propTypes = {
+  isLoggedIn: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,
   scrollTo: PropTypes.bool,
   selected: PropTypes.bool.isRequired,

--- a/app/components/reservation/TimeSlots.js
+++ b/app/components/reservation/TimeSlots.js
@@ -12,12 +12,13 @@ class TimeSlots extends Component {
   }
 
   renderTimeSlot(slot) {
-    const { onClick, selected, time } = this.props;
+    const { isLoggedIn, onClick, selected, time } = this.props;
     const scrollTo = time && time === slot.start;
 
     return (
       <TimeSlot
         key={slot.start}
+        isLoggedIn={isLoggedIn}
         onClick={onClick}
         scrollTo={scrollTo}
         selected={_.includes(selected, slot.asISOString)}
@@ -57,6 +58,7 @@ class TimeSlots extends Component {
 
 TimeSlots.propTypes = {
   isFetching: PropTypes.bool.isRequired,
+  isLoggedIn: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,
   selected: PropTypes.array.isRequired,
   slots: PropTypes.array.isRequired,

--- a/app/components/reservation/__tests__/TimeSlot.spec.js
+++ b/app/components/reservation/__tests__/TimeSlot.spec.js
@@ -10,6 +10,7 @@ import TimeSlotFixture from 'fixtures/TimeSlot';
 
 describe('Component: reservation/TimeSlot', () => {
   const props = {
+    isLoggedIn: true,
     onClick: simple.stub(),
     selected: false,
     slot: Immutable(TimeSlotFixture.build()),
@@ -84,6 +85,7 @@ describe('Component: reservation/TimeSlot', () => {
 
       describe('when the slot is reserved', () => {
         const reservedProps = {
+          isLoggedIn: true,
           onClick: simple.stub(),
           selected: false,
           slot: Immutable(TimeSlotFixture.build({ reserved: true })),

--- a/app/components/reservation/__tests__/TimeSlots.spec.js
+++ b/app/components/reservation/__tests__/TimeSlots.spec.js
@@ -16,6 +16,7 @@ describe('Component: reservation/TimeSlots', () => {
     ];
     const props = {
       isFetching: false,
+      isLoggedIn: true,
       onClick: simple.stub(),
       selected: [timeSlots[0].asISOString],
       slots: Immutable(timeSlots),
@@ -69,6 +70,7 @@ describe('Component: reservation/TimeSlots', () => {
 
       it('should pass correct props to TimeSlots', () => {
         timeSlotTrees.forEach((timeSlotTree, index) => {
+          expect(timeSlotTree.props.isLoggedIn).to.equal(props.isLoggedIn);
           expect(timeSlotTree.props.onClick).to.equal(props.onClick);
           expect(timeSlotTree.props.slot).to.deep.equal(props.slots[index]);
         });
@@ -84,6 +86,7 @@ describe('Component: reservation/TimeSlots', () => {
   describe('without timeslots', () => {
     const props = {
       isFetching: false,
+      isLoggedIn: true,
       onClick: simple.stub(),
       selected: [],
       slots: [],

--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -94,6 +94,7 @@ export class UnconnectedReservationForm extends Component {
       confirmReservationModalIsOpen,
       date,
       isFetchingResource,
+      isLoggedIn,
       isMakingReservations,
       reservationsToEdit,
       selected,
@@ -118,13 +119,14 @@ export class UnconnectedReservationForm extends Component {
         />
         <TimeSlots
           isFetching={isFetchingResource}
+          isLoggedIn={isLoggedIn}
           onClick={actions.toggleTimeSlot}
           selected={selected}
           slots={timeSlots}
           time={time}
         />
         <ReservationFormControls
-          disabled={!selected.length || isMakingReservations}
+          disabled={!isLoggedIn || !selected.length || isMakingReservations}
           isEditing={isEditing}
           isMakingReservations={isMakingReservations}
           onCancel={this.handleEditCancel}
@@ -150,6 +152,7 @@ UnconnectedReservationForm.propTypes = {
   date: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   isFetchingResource: PropTypes.bool.isRequired,
+  isLoggedIn: PropTypes.bool.isRequired,
   isMakingReservations: PropTypes.bool.isRequired,
   reservationsToEdit: PropTypes.array.isRequired,
   selected: PropTypes.array.isRequired,

--- a/app/containers/ReservationPage.js
+++ b/app/containers/ReservationPage.js
@@ -27,6 +27,7 @@ export class UnconnectedReservationPage extends Component {
     const {
       id,
       isFetchingResource,
+      isLoggedIn,
       resource,
       unit,
     } = this.props;
@@ -53,7 +54,10 @@ export class UnconnectedReservationPage extends Component {
               address={getAddressWithName(unit)}
               name={resourceName}
             />
-          <h2>Varaa tila</h2>
+          <h2>{isLoggedIn ? 'Varaa tila' : 'Varaustilanne'}</h2>
+          {!isLoggedIn &&
+            <p><a href="/login">Kirjaudu sisään</a> voidaksesi tehdä varauksen tähän tilaan.</p>
+          }
           <ReservationForm />
           </div>
         </Loader>
@@ -67,6 +71,7 @@ UnconnectedReservationPage.propTypes = {
   date: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   isFetchingResource: PropTypes.bool.isRequired,
+  isLoggedIn: PropTypes.bool.isRequired,
   resource: PropTypes.object.isRequired,
   unit: PropTypes.object.isRequired,
 };

--- a/app/containers/ReservationsTable.js
+++ b/app/containers/ReservationsTable.js
@@ -103,7 +103,7 @@ export class UnconnectedReservationsTable extends Component {
             />
           </div>
         ) : (
-          <p>Sinulla ei vielä ole yhtään varauksia.</p>
+          <p>Sinulla ei vielä ole yhtään varausta.</p>
         )}
       </Loader>
     );

--- a/app/containers/ResourcePage.js
+++ b/app/containers/ResourcePage.js
@@ -30,6 +30,7 @@ export class UnconnectedResourcePage extends Component {
     const {
       id,
       isFetchingResource,
+      isLoggedIn,
       resource,
       unit,
     } = this.props;
@@ -53,7 +54,7 @@ export class UnconnectedResourcePage extends Component {
                 bsStyle="primary"
                 className="reserve-button"
               >
-                Varaa tila
+                {isLoggedIn ? 'Varaa tila' : 'Varaustilanne'}
               </Button>
             </LinkContainer>
             <ResourceDetails
@@ -76,6 +77,7 @@ UnconnectedResourcePage.propTypes = {
   actions: PropTypes.object.isRequired,
   id: PropTypes.string.isRequired,
   isFetchingResource: PropTypes.bool.isRequired,
+  isLoggedIn: PropTypes.bool.isRequired,
   resource: PropTypes.object.isRequired,
   unit: PropTypes.object.isRequired,
 };

--- a/app/containers/__tests__/ReservationForm.spec.js
+++ b/app/containers/__tests__/ReservationForm.spec.js
@@ -27,6 +27,7 @@ function getProps(props = {}) {
     date: '2015-10-11',
     id: 'r-1',
     isFetchingResource: false,
+    isLoggedIn: true,
     isMakingReservations: false,
     reservationsToEdit: [],
     timeSlots: [],
@@ -104,6 +105,7 @@ describe('Container: ReservationForm', () => {
         const actualProps = timeSlotsTrees[0].props;
 
         expect(actualProps.isFetching).to.equal(props.isFetchingResource);
+        expect(actualProps.isLoggedIn).to.equal(props.isLoggedIn);
         expect(actualProps.onClick).to.deep.equal(props.actions.toggleTimeSlot);
         expect(actualProps.selected).to.deep.equal(props.selected);
         expect(actualProps.slots).to.deep.equal(props.timeSlots);

--- a/app/containers/__tests__/ReservationPage.spec.js
+++ b/app/containers/__tests__/ReservationPage.spec.js
@@ -16,6 +16,7 @@ describe('Container: ReservationPage', () => {
     date: '2015-10-10',
     id: resource.id,
     isFetchingResource: false,
+    isLoggedIn: true,
     resource: Immutable(resource),
     unit: Immutable(unit),
   };

--- a/app/containers/__tests__/ReservationsTable.spec.js
+++ b/app/containers/__tests__/ReservationsTable.spec.js
@@ -175,7 +175,7 @@ describe('Component: reservation/ReservationsTable', () => {
     });
 
     it('should render a message telling no reservations were found', () => {
-      const expected = 'Sinulla ei vielä ole yhtään varauksia.';
+      const expected = 'Sinulla ei vielä ole yhtään varausta.';
 
       expect(tree.textIn('p')).to.equal(expected);
     });

--- a/app/containers/__tests__/ResourcePage.spec.js
+++ b/app/containers/__tests__/ResourcePage.spec.js
@@ -19,6 +19,7 @@ describe('Container: ResourcePage', () => {
     actions: { fetchResource: simple.stub() },
     id: resource.id,
     isFetchingResource: false,
+    isLoggedIn: true,
     resource: Immutable(resource),
     unit: Immutable(unit),
   };

--- a/app/selectors/__tests__/isLoggedInSelector.spec.js
+++ b/app/selectors/__tests__/isLoggedInSelector.spec.js
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+
+import isLoggedInSelector from 'selectors/isLoggedInSelector';
+
+function getState(token = null, userId = null) {
+  return {
+    auth: {
+      token,
+      userId,
+    },
+  };
+}
+
+describe('Selector: isLoggedInSelector', () => {
+  it('should return false if token is null', () => {
+    const state = getState(null, 'u-1');
+    const actual = isLoggedInSelector(state);
+
+    expect(actual).to.equal(false);
+  });
+
+  it('should return false if userId is null', () => {
+    const state = getState('mock-token', null);
+    const actual = isLoggedInSelector(state);
+
+    expect(actual).to.equal(false);
+  });
+
+  it('should return true if both token and userId are defined', () => {
+    const state = getState('mock-token', 'u-1');
+    const actual = isLoggedInSelector(state);
+
+    expect(actual).to.equal(true);
+  });
+});

--- a/app/selectors/containers/__tests__/reservationFormSelector.spec.js
+++ b/app/selectors/containers/__tests__/reservationFormSelector.spec.js
@@ -14,6 +14,10 @@ function getState(resource, resourceId) {
     api: Immutable({
       activeRequests: [],
     }),
+    auth: {
+      token: null,
+      userId: null,
+    },
     data: Immutable({
       resources: { [resource.id]: resource },
     }),
@@ -79,6 +83,13 @@ describe('Selector: reservationFormSelector', () => {
     const selected = reservationFormSelector(state);
 
     expect(selected.isFetchingResource).to.exist;
+  });
+
+  it('should return isLoggedIn', () => {
+    const state = getState(resource);
+    const selected = reservationFormSelector(state);
+
+    expect(selected.isLoggedIn).to.exist;
   });
 
   it('should return isMakingReservations', () => {

--- a/app/selectors/containers/__tests__/reservationPageSelector.spec.js
+++ b/app/selectors/containers/__tests__/reservationPageSelector.spec.js
@@ -12,6 +12,10 @@ function getState(resources = [], units = [], resourceId = 'some-id') {
     api: Immutable({
       activeRequests: [],
     }),
+    auth: {
+      token: null,
+      userId: null,
+    },
     data: Immutable({
       resources: _.indexBy(resources, 'id'),
       units: _.indexBy(units, 'id'),
@@ -50,6 +54,13 @@ describe('Selector: reservationPageSelector', () => {
     const selected = reservationPageSelector(state);
 
     expect(selected.isFetchingResource).to.exist;
+  });
+
+  it('should return isLoggedIn', () => {
+    const state = getState();
+    const selected = reservationPageSelector(state);
+
+    expect(selected.isLoggedIn).to.exist;
   });
 
   it('should return resource', () => {

--- a/app/selectors/containers/__tests__/resourcePageSelector.spec.js
+++ b/app/selectors/containers/__tests__/resourcePageSelector.spec.js
@@ -12,6 +12,10 @@ function getState(resources = [], units = [], resourceId = 'some-id') {
     api: Immutable({
       activeRequests: [],
     }),
+    auth: {
+      token: null,
+      userId: null,
+    },
     data: Immutable({
       resources: _.indexBy(resources, 'id'),
       units: _.indexBy(units, 'id'),
@@ -38,6 +42,13 @@ describe('Selector: resourcePageSelector', () => {
     const selected = resourcePageSelector(state);
 
     expect(selected.isFetchingResource).to.exist;
+  });
+
+  it('should return isLoggedIn', () => {
+    const state = getState();
+    const selected = resourcePageSelector(state);
+
+    expect(selected.isLoggedIn).to.exist;
   });
 
   it('should return resource', () => {

--- a/app/selectors/containers/reservationFormSelector.js
+++ b/app/selectors/containers/reservationFormSelector.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 
 import ActionTypes from 'constants/ActionTypes';
 import dateSelector from 'selectors/dateSelector';
+import isLoggedInSelector from 'selectors/isLoggedInSelector';
 import resourceSelector from 'selectors/resourceSelector';
 import timeSelector from 'selectors/timeSelector';
 import selectedReservationsSelector from 'selectors/selectedReservationsSelector';
@@ -17,6 +18,7 @@ const toEditSelector = (state) => state.ui.reservation.toEdit;
 
 const reservationFormSelector = createSelector(
   idSelector,
+  isLoggedInSelector,
   modalIsOpenSelectorFactory(ModalTypes.CONFIRM_RESERVATION),
   requestIsActiveSelectorFactory(ActionTypes.API.RESERVATION_POST_REQUEST),
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
@@ -28,6 +30,7 @@ const reservationFormSelector = createSelector(
   toEditSelector,
   (
     id,
+    isLoggedIn,
     confirmReservationModalIsOpen,
     isMakingReservations,
     isFetchingResource,
@@ -48,6 +51,7 @@ const reservationFormSelector = createSelector(
       date,
       id,
       isFetchingResource,
+      isLoggedIn,
       isMakingReservations,
       reservationsToEdit,
       selected,

--- a/app/selectors/containers/reservationPageSelector.js
+++ b/app/selectors/containers/reservationPageSelector.js
@@ -3,21 +3,24 @@ import { createSelector } from 'reselect';
 import ActionTypes from 'constants/ActionTypes';
 import resourceSelector from 'selectors/resourceSelector';
 import dateSelector from 'selectors/dateSelector';
+import isLoggedInSelector from 'selectors/isLoggedInSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
 const idSelector = (state) => state.router.params.id;
 const unitsSelector = (state) => state.data.units;
 
 const reservationPageSelector = createSelector(
-  idSelector,
-  requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   dateSelector,
+  idSelector,
+  isLoggedInSelector,
+  requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   resourceSelector,
   unitsSelector,
   (
-    id,
-    isFetchingResource,
     date,
+    id,
+    isLoggedIn,
+    isFetchingResource,
     resource,
     units
   ) => {
@@ -27,6 +30,7 @@ const reservationPageSelector = createSelector(
       date,
       id,
       isFetchingResource,
+      isLoggedIn,
       resource,
       unit,
     };

--- a/app/selectors/containers/resourcePageSelector.js
+++ b/app/selectors/containers/resourcePageSelector.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 
 import ActionTypes from 'constants/ActionTypes';
+import isLoggedInSelector from 'selectors/isLoggedInSelector';
 import resourceSelector from 'selectors/resourceSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
@@ -9,11 +10,13 @@ const unitsSelector = (state) => state.data.units;
 
 const resourcePageSelector = createSelector(
   idSelector,
+  isLoggedInSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   resourceSelector,
   unitsSelector,
   (
     id,
+    isLoggedIn,
     isFetchingResource,
     resource,
     units
@@ -23,6 +26,7 @@ const resourcePageSelector = createSelector(
     return {
       id,
       isFetchingResource,
+      isLoggedIn,
       resource,
       unit,
     };

--- a/app/selectors/isLoggedInSelector.js
+++ b/app/selectors/isLoggedInSelector.js
@@ -1,0 +1,3 @@
+const isLoggedInSelector = (state) => Boolean(state.auth.userId && state.auth.token);
+
+export default isLoggedInSelector;


### PR DESCRIPTION
This PR:
- Makes making reservations disabled for logged out users.
- Changes reservations headers based on whether user is logged in or out -> "Varaa tila" vs "Varaustilanne".
- Displays a login link on reservation page if user is not logged in.
- Improves my reservations page no reservations message grammar.

Closes #87.