### PR TITLE
Make sure PUT request goes through before POSTs

### DIFF
--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -62,9 +62,16 @@ export class UnconnectedReservationForm extends Component {
       ));
 
       // Add new reservations if needed.
-      _.forEach(_.rest(selectedReservations), (reservation) => {
-        actions.postReservation(reservation);
-      });
+      // FIXME: This is very hacky and not bulletproof but use cases where user splits
+      // one reservation into multiple reservations should be pretty rare.
+      // Try to use something sequential in the future.
+      // Use timeout to allow the PUT request to go through first and possibly free previously
+      // reserved time slots.
+      setTimeout(() => {
+        _.forEach(_.rest(selectedReservations), (reservation) => {
+          actions.postReservation(reservation);
+        });
+      }, 800);
     } else {
       // Delete the edited reservation if no time slots were selected.
       _.forEach(reservationsToEdit, (reservation) => {


### PR DESCRIPTION
This PR doesn't prevent user from splitting a reservation into multiple reservations in the edit mode, but makes it pretty sure that all requests will proceed without errors.
This is very hacky and not bulletproof but use cases where user splits
one reservation into multiple reservations should be pretty rare.
In the future the timeout should be replaced by something sequential.
The timeout allows the PUT request to go through first and
possibly free previously reserved time slots, that might be
needed in the POST requests.
Closes #147.