### PR TITLE
Remove unneeded input placeholders

### DIFF
--- a/app/components/search/SearchFilters.js
+++ b/app/components/search/SearchFilters.js
@@ -13,14 +13,14 @@ class SearchFilters extends Component {
 
     return (
       <div style={{ marginBottom: '20px' }}>
-        <h4>Käyttötarkoitus</h4>
+        <h4>Tilan käyttötarkoitus</h4>
         <Select
           clearable
           isLoading={isFetchingPurposes}
           name="purpose-filter-select"
           onChange={(value) => onFiltersChange({ purpose: value })}
           options={purposeOptions}
-          placeholder="Rajaa hakutuloksia käyttötarkoituksen mukaan"
+          placeholder=" "
           value={filters.purpose}
         />
         <h4>Tilan henkilömäärä vähintään</h4>
@@ -28,7 +28,6 @@ class SearchFilters extends Component {
           min="0"
           name="people-capacity-filter"
           onChange={(event) => onFiltersChange({ people: event.target.value })}
-          placeholder="Rajaa hakutuloksia henkilömäärän mukaan"
           type="number"
           value={filters.people}
         />

--- a/app/components/search/SearchInput.js
+++ b/app/components/search/SearchInput.js
@@ -15,7 +15,6 @@ class SearchInput extends Component {
         <Input
           autoFocus={autoFocus}
           onChange={(event) => onChange(event.target.value)}
-          placeholder="Etsi tilan nimellä"
           ref="searchInput"
           type="text"
           value={value}

--- a/app/components/search/__tests__/SearchInput.spec.js
+++ b/app/components/search/__tests__/SearchInput.spec.js
@@ -40,7 +40,6 @@ describe('Component: search/SearchInput', () => {
       expect(actualProps.autoFocus).to.equal(props.autoFocus);
       expect(actualProps.value).to.equal(props.value);
       expect(actualProps.type).to.equal('text');
-      expect(actualProps.placeholder).to.equal('Etsi tilan nimellä');
     });
 
     it('changing the search box value should call props.onChange with new value', () => {


### PR DESCRIPTION
Makes the UI more clean and does not restrict user as much.
Closes #165.