### PR TITLE
Include Authorization header in all API requests

### DIFF
--- a/app/actions/reservationActions.js
+++ b/app/actions/reservationActions.js
@@ -39,7 +39,7 @@ function deleteReservation(reservation) {
       ],
       endpoint: reservation.url,
       method: 'DELETE',
-      headers: getHeadersCreator({}, { withJWT: true }),
+      headers: getHeadersCreator(),
     },
   };
 }
@@ -59,7 +59,7 @@ function fetchReservations(params = {}) {
       ],
       endpoint: buildAPIUrl('reservation', fetchParams),
       method: 'GET',
-      headers: getHeadersCreator({}, { withJWT: true }),
+      headers: getHeadersCreator(),
     },
   };
 }
@@ -85,7 +85,7 @@ function postReservation(reservation) {
       ],
       endpoint: url,
       method: 'POST',
-      headers: getHeadersCreator({}, { withJWT: true }),
+      headers: getHeadersCreator(),
       body: JSON.stringify(reservation),
     },
   };
@@ -110,7 +110,7 @@ function putReservation(reservation) {
       ],
       endpoint: reservation.url,
       method: 'PUT',
-      headers: getHeadersCreator({}, { withJWT: true }),
+      headers: getHeadersCreator(),
       body: JSON.stringify(reservation),
     },
   };

--- a/app/utils/APIUtils.js
+++ b/app/utils/APIUtils.js
@@ -52,10 +52,10 @@ function getErrorTypeDescriptor(type, options = {}) {
   };
 }
 
-function getHeadersCreator(headers, options = {}) {
+function getHeadersCreator(headers) {
   return (state) => {
     const authorizationHeaders = {};
-    if (options.withJWT && state.auth.token) {
+    if (state.auth.token) {
       authorizationHeaders.Authorization = `JWT ${state.auth.token}`;
     }
     return Object.assign({}, REQUIRED_API_HEADERS, headers, authorizationHeaders);

--- a/app/utils/__tests__/APIUtils.spec.js
+++ b/app/utils/__tests__/APIUtils.spec.js
@@ -157,16 +157,20 @@ describe('Utils: APIUtils', () => {
         const authorizationHeader = { Authorization: 'JWT mock-token' };
 
         describe('if no additional headers are specified', () => {
-          it('should return just the required headers', () => {
+          it('should return the required headers and Authorization header', () => {
             const creator = getHeadersCreator();
-            const expected = Object.assign({}, REQUIRED_API_HEADERS);
+            const expected = Object.assign(
+              {},
+              REQUIRED_API_HEADERS,
+              authorizationHeader
+            );
 
             expect(creator(state)).to.deep.equal(expected);
           });
         });
 
         describe('if additional headers are specified', () => {
-          it('should return the required headers and the additional headers', () => {
+          it('should return the required, the additional and Authorization headers', () => {
             const additionalHeaders = {
               header: 'value',
             };
@@ -174,22 +178,7 @@ describe('Utils: APIUtils', () => {
             const expected = Object.assign(
               {},
               REQUIRED_API_HEADERS,
-              additionalHeaders
-            );
-
-            expect(creator(state)).to.deep.equal(expected);
-          });
-        });
-
-        describe('if options contain withJWT', () => {
-          it('should return the required headers and the Authorization header', () => {
-            const options = {
-              withJWT: true,
-            };
-            const creator = getHeadersCreator({}, options);
-            const expected = Object.assign(
-              {},
-              REQUIRED_API_HEADERS,
+              additionalHeaders,
               authorizationHeader
             );
 
@@ -218,21 +207,6 @@ describe('Utils: APIUtils', () => {
             };
             const creator = getHeadersCreator(additionalHeaders);
             const expected = Object.assign({}, REQUIRED_API_HEADERS, additionalHeaders);
-
-            expect(creator(state)).to.deep.equal(expected);
-          });
-        });
-
-        describe('if options contain withJWT', () => {
-          it('should only return the required headers and no Authorization header', () => {
-            const options = {
-              withJWT: true,
-            };
-            const creator = getHeadersCreator({}, options);
-            const expected = Object.assign(
-              {},
-              REQUIRED_API_HEADERS
-            );
 
             expect(creator(state)).to.deep.equal(expected);
           });


### PR DESCRIPTION
Include the Authorization header to all API calls if user is logged in.
Closes #176.