### PR TITLE
Add Accept-Language header to all API requests

### DIFF
--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -9,6 +9,7 @@ export default {
   },
   REQUIRED_API_HEADERS: {
     'Accept': 'application/json',
+    'Accept-Language': 'fi',
     'Content-Type': 'application/json',
   },
   SUPPORTED_SEARCH_FILTERS: {


### PR DESCRIPTION
In the pilot version of the service the Accept-Language is always "fi".
Closes #188.