### PR TITLE
Feature/184 remove parent purposes from purpose select

### DIFF
--- a/app/selectors/__tests__/purposeOptionsSelector.spec.js
+++ b/app/selectors/__tests__/purposeOptionsSelector.spec.js
@@ -27,11 +27,19 @@ describe('Selector: purposeOptionsSelector', () => {
     expect(actual).to.deep.equal([]);
   });
 
-  it('should return an option object for each purpose in state', () => {
+  it('should return an option object for each purpose with a parent', () => {
     const state = getState(purposes);
     const actual = purposeOptionsSelector(state);
 
     expect(actual.length).to.equal(purposes.length);
+  });
+
+  it('should not return an option object for purposes without a parent', () => {
+    const parentlessPurpose = Purpose.build({ parent: null });
+    const state = getState([parentlessPurpose]);
+    const actual = purposeOptionsSelector(state);
+
+    expect(actual.length).to.equal(0);
   });
 
   describe('a returned option object', () => {

--- a/app/selectors/purposeOptionsSelector.js
+++ b/app/selectors/purposeOptionsSelector.js
@@ -17,8 +17,9 @@ const purposeOptionsSelector = createSelector(
         label: getName(purpose),
       };
     });
+    const alphabetized = _.sortBy(purposeOptions, 'label');
 
-    return Immutable(purposeOptions);
+    return Immutable(alphabetized);
   }
 );
 

--- a/app/selectors/purposeOptionsSelector.js
+++ b/app/selectors/purposeOptionsSelector.js
@@ -9,14 +9,16 @@ const purposesSelector = (state) => state.data.purposes;
 const purposeOptionsSelector = createSelector(
   purposesSelector,
   (purposes) => {
-    const purposeOptions = Immutable(_.values(purposes).map(purpose => {
+    const purposeOptions = _.filter(
+      _.values(purposes), (purpose) => purpose.parent !== null
+    ).map(purpose => {
       return {
         value: purpose.id,
         label: getName(purpose),
       };
-    }));
+    });
 
-    return purposeOptions;
+    return Immutable(purposeOptions);
   }
 );
 


### PR DESCRIPTION
This PR:
- Removes parent purposes from search page purpose select.
- Alphabetizes purpose select options.

Closes #184.
