### PR TITLE
Feature/190 change respa to varaamo

### DIFF
--- a/app/components/layout/Footer.js
+++ b/app/components/layout/Footer.js
@@ -21,7 +21,7 @@ class Footer extends Component {
                   src={logoSrc}
                   style={styles.logo}
                 />
-                Respa
+                Varaamo
               </RadiumLink>
             </Col>
             <Col lg={6} md={6}>

--- a/app/components/layout/Footer.js
+++ b/app/components/layout/Footer.js
@@ -3,10 +3,18 @@ import React, { Component } from 'react';
 import { Grid, Row, Col } from 'react-bootstrap';
 import { Link } from 'react-router';
 
+import { FEEDBACK_URL } from 'constants/AppConstants';
+
 import styles from './Footer.styles';
 import logoSrc from 'assets/images/helsinki-coat-of-arms-white.png';
 
 class Footer extends Component {
+  handleFeedbackClick(event) {
+    event.preventDefault();
+    const refUrl = window.location.href;
+    window.location = `${FEEDBACK_URL}?ref=${refUrl}`;
+  }
+
   render() {
     const RadiumLink = Radium(Link);
 
@@ -25,8 +33,15 @@ class Footer extends Component {
               </RadiumLink>
             </Col>
             <Col lg={6} md={6}>
-              <p>Tämä on palvelun ensimmäinen pilottiversio, josta toivomme käyttäjiltä palautetta.</p>
-              <p>Palautetta voit lähettää sähköpostilla osoitteeseen <a href="mailto:esimerkki@hel.fi" style={styles.link}>esimerkki@hel.fi</a>.</p>
+              <p>
+                Varaamo on Helsingin kaupungin tilanvarauspalvelu.
+                Kyseessä on pilottiversio, josta toivomme Sinulta palautetta.
+                Palautteesi voit lähettää <a
+                  href={FEEDBACK_URL}
+                  onClick={this.handleFeedbackClick}
+                  style={styles.link}
+                >täältä</a>.
+              </p>
             </Col>
           </Row>
         </Grid>

--- a/app/components/layout/Footer.js
+++ b/app/components/layout/Footer.js
@@ -17,6 +17,15 @@ class Footer extends Component {
 
   render() {
     const RadiumLink = Radium(Link);
+    const feedbackLink = (
+      <a
+        href={FEEDBACK_URL}
+        onClick={this.handleFeedbackClick}
+        style={styles.link}
+      >
+        täältä
+      </a>
+    );
 
     return (
       <footer style={styles.footer}>
@@ -36,11 +45,7 @@ class Footer extends Component {
               <p>
                 Varaamo on Helsingin kaupungin tilanvarauspalvelu.
                 Kyseessä on pilottiversio, josta toivomme Sinulta palautetta.
-                Palautteesi voit lähettää <a
-                  href={FEEDBACK_URL}
-                  onClick={this.handleFeedbackClick}
-                  style={styles.link}
-                >täältä</a>.
+                Palautteesi voit lähettää {feedbackLink}.
               </p>
             </Col>
           </Row>

--- a/app/components/layout/Navbar.js
+++ b/app/components/layout/Navbar.js
@@ -60,7 +60,7 @@ class Navbar extends Component {
                 src={logoSrc}
                 style={styles.logo}
               />
-              Respa
+              Varaamo
             </Link>
           </RBNavbar.Brand>
           <RBNavbar.Toggle />

--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -1,6 +1,7 @@
 export default {
   API_URL: 'https://api.hel.fi/respa/v1',
   DATE_FORMAT: 'YYYY-MM-DD',
+  FEEDBACK_URL: 'http://www.helmet-kirjasto.fi/respa-palaute/',
   NOTIFICATION_DEFAULTS: {
     message: '',
     type: 'info',

--- a/app/containers/AboutPage.js
+++ b/app/containers/AboutPage.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import DocumentTitle from 'react-document-title';
 
+import { FEEDBACK_URL } from 'constants/AppConstants';
+
 class AboutPage extends Component {
   render() {
     const refUrl = window.location.href;
@@ -40,7 +42,7 @@ class AboutPage extends Component {
           <p>
             Palvelua kehitetään edelleen ja toivomme palvelun käyttäjiltä palautetta. Palautetta
             voit antaa <a
-              href={`http://www.helmet-kirjasto.fi/respa-palaute/?url=${refUrl}`}
+              href={`${FEEDBACK_URL}?ref=${refUrl}`}
             >tämän linkin</a> kautta.
           </p>
         </div>

--- a/app/containers/AboutPage.js
+++ b/app/containers/AboutPage.js
@@ -3,36 +3,45 @@ import DocumentTitle from 'react-document-title';
 
 class AboutPage extends Component {
   render() {
+    const refUrl = window.location.href;
+
     return (
       <DocumentTitle title="Tietoa palvelusta - Varaamo">
         <div className="about-page">
-          <h1>Tietoa respa.hel.fi –palvelusta</h1>
+          <h1>Tietoa varaamo.hel.fi –palvelusta</h1>
           <p className="lead">
-            Varaamo on Helsingin kaupungin ylläpitämä verkkopalvelu, jonka kautta voidaan varata
+            Varaamo on on Helsingin kaupungin ylläpitämä verkkopalvelu, jonka kautta voi varata
             kaupungin julkisia tiloja sekä työpisteitä yksityiseen käyttöön.
           </p>
           <p>
-            Palvelu on testausvaiheessa, ja sen pilottikäytössä olevassa versiossa ei ole vielä
-            kaikkia suunnitteilla olevia ominaisuuksia ja toiminnallisuuksia. Testiversion
-            tarkoituksena on kaupungin sisäisten tilavarauskäytäntöjen yhtenäistämisen ohella
-            saada palautetta myös itse palvelusta ja sen toiminnasta. <strong>Palautetta voi antaa
-            joka sivulla sijaitsevan palautelaatikon kautta. ?</strong>
+            Tilavarausjärjestelmä on testausvaiheessa, eikä pilottikäytössä olevassa versiossa
+            ole vielä kaikkia suunnitteilla olevia ominaisuuksia ja toiminnallisuuksia.
           </p>
           <p>
             Pilottivaiheessa palvelun kautta on varattavissa kaupunginkirjaston,
-            nuorisoasiainkeskuksen sekä varhaiskasvatusviraston tiloja ja työpisteitä. Osa palvelun
-            kautta tarjottavista tiloista on maksullisia ja niiden varaaminen suoraan
-            tilavarausjärjestelmän kautta ei ole alkuvaiheessa mahdollista, vaan maksullisista
-            tiloista nähtävissä ovat varauskalenteri sekä tarvittavat yhteystiedot tilavarauksen
-            tekemiseen.
+            nuorisoasiainkeskuksen sekä varhaiskasvatusviraston tiloja, työpisteitä ja laitteita.
           </p>
           <p>
-            Varaamo-tilavarausjärjestelmän kehittäminen toimii osana Helsingin kaupungin
-            strategiaohjelman 2013 - 2016 (Tehokkaat ja toimivat tukipalvelut) sekä
-            tietotekniikkaohjelman 2015 - 2017 (Datarajapinnat ja avoin kaupunkikehitys)
-            jalkauttamista. Virastoyhteisen tilavarauskokeilun tavoitteena on julkisten tilojen
-            käytön tehostaminen, saavutettavuuden parantaminen ja tilojen käyttöön liittyvien
-            kustannusten alentaminen.
+            Osa palvelun kautta tarjottavista tiloista on maksullisia. Maksullisten tilojen
+            varaaminen ei kuitenkaan ole vielä pilotin ensimmäisessä vaiheessa mahdollista.
+            Maksulliset tilat näkyvät varauskalenterissa ja niiden yhteydessä on tarvittavat
+            yhteystiedot tilavarauksen tekemiseen sähköpostilla tai puhelimitse.
+          </p>
+          <p>
+            Varaamo-tilavarausjärjestelmän kehittäminen on osa Helsingin kaupungin strategiaohjelmaa
+            2013 - 2016 (Tehokkaat ja toimivat tukipalvelut) sekä tietotekniikkaohjelmaa 2015 - 2017
+            (Datarajapinnat ja avoin kaupunkikehitys).
+          </p>
+          <p>
+            Virastoyhteisen tilavaraushankkeen tavoitteena on julkisten tilojen käytön tehostaminen,
+            saavutettavuuden parantaminen ja tilojen käyttöön liittyvien kustannusten alentaminen
+            kaupungin tilavarauskäytäntöjä yhtenäistämällä.
+          </p>
+          <p>
+            Palvelua kehitetään edelleen ja toivomme palvelun käyttäjiltä palautetta. Palautetta
+            voit antaa <a
+              href={`http://www.helmet-kirjasto.fi/respa-palaute/?url=${refUrl}`}
+            >tämän linkin</a> kautta.
           </p>
         </div>
       </DocumentTitle>

--- a/app/containers/AboutPage.js
+++ b/app/containers/AboutPage.js
@@ -6,6 +6,11 @@ import { FEEDBACK_URL } from 'constants/AppConstants';
 class AboutPage extends Component {
   render() {
     const refUrl = window.location.href;
+    const feedbackLink = (
+      <a href={`${FEEDBACK_URL}?ref=${refUrl}`}>
+        tämän linkin
+      </a>
+    );
 
     return (
       <DocumentTitle title="Tietoa palvelusta - Varaamo">
@@ -41,9 +46,7 @@ class AboutPage extends Component {
           </p>
           <p>
             Palvelua kehitetään edelleen ja toivomme palvelun käyttäjiltä palautetta. Palautetta
-            voit antaa <a
-              href={`${FEEDBACK_URL}?ref=${refUrl}`}
-            >tämän linkin</a> kautta.
+            voit antaa {feedbackLink} kautta.
           </p>
         </div>
       </DocumentTitle>

--- a/app/containers/AboutPage.js
+++ b/app/containers/AboutPage.js
@@ -4,11 +4,11 @@ import DocumentTitle from 'react-document-title';
 class AboutPage extends Component {
   render() {
     return (
-      <DocumentTitle title="Tietoa palvelusta - Respa">
+      <DocumentTitle title="Tietoa palvelusta - Varaamo">
         <div className="about-page">
           <h1>Tietoa respa.hel.fi –palvelusta</h1>
           <p className="lead">
-            Respa on Helsingin kaupungin ylläpitämä verkkopalvelu, jonka kautta voidaan varata
+            Varaamo on Helsingin kaupungin ylläpitämä verkkopalvelu, jonka kautta voidaan varata
             kaupungin julkisia tiloja sekä työpisteitä yksityiseen käyttöön.
           </p>
           <p>
@@ -27,7 +27,7 @@ class AboutPage extends Component {
             tekemiseen.
           </p>
           <p>
-            Respa-tilavarausjärjestelmän kehittäminen toimii osana Helsingin kaupungin
+            Varaamo-tilavarausjärjestelmän kehittäminen toimii osana Helsingin kaupungin
             strategiaohjelman 2013 - 2016 (Tehokkaat ja toimivat tukipalvelut) sekä
             tietotekniikkaohjelman 2015 - 2017 (Datarajapinnat ja avoin kaupunkikehitys)
             jalkauttamista. Virastoyhteisen tilavarauskokeilun tavoitteena on julkisten tilojen

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -34,7 +34,7 @@ export class UnconnectedApp extends Component {
     } = this.props;
 
     return (
-      <DocumentTitle title="Respa">
+      <DocumentTitle title="Varaamo">
         <div className="app">
           <Navbar
             clearSearchResults={actions.clearSearchResults}

--- a/app/containers/HomePage.js
+++ b/app/containers/HomePage.js
@@ -6,7 +6,7 @@ import PurposeCategoryList from 'containers/PurposeCategoryList';
 class HomePage extends Component {
   render() {
     return (
-      <DocumentTitle title="Etusivu - Respa">
+      <DocumentTitle title="Etusivu - Varaamo">
         <div>
           <h2>Mitä haluat tehdä?</h2>
           <PurposeCategoryList />

--- a/app/containers/NotFoundPage.js
+++ b/app/containers/NotFoundPage.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router';
 class NotFoundPage extends Component {
   render() {
     return (
-      <DocumentTitle title="404 Sivua ei löydy - Respa">
+      <DocumentTitle title="404 Sivua ei löydy - Varaamo">
         <div>
           <h1>404 Sivua ei löydy</h1>
           <p className="lead">

--- a/app/containers/ReservationPage.js
+++ b/app/containers/ReservationPage.js
@@ -48,7 +48,7 @@ export class UnconnectedReservationPage extends Component {
     }
 
     return (
-      <DocumentTitle title={`${resourceName} varaaminen - Respa`}>
+      <DocumentTitle title={`${resourceName} varaaminen - Varaamo`}>
         <Loader loaded={!_.isEmpty(resource)}>
           <div className="reservation-page"v>
             <ResourceHeader

--- a/app/containers/ResourcePage.js
+++ b/app/containers/ResourcePage.js
@@ -41,7 +41,7 @@ export class UnconnectedResourcePage extends Component {
     }
 
     return (
-      <DocumentTitle title={`${resourceName} - Respa`}>
+      <DocumentTitle title={`${resourceName} - Varaamo`}>
         <Loader loaded={!_.isEmpty(resource)}>
           <div className="resource-page">
             <ResourceHeader

--- a/app/containers/SearchPage.js
+++ b/app/containers/SearchPage.js
@@ -41,7 +41,7 @@ export class UnconnectedSearchPage extends Component {
     } = this.props;
 
     return (
-      <DocumentTitle title="Haku - Respa">
+      <DocumentTitle title="Haku - Varaamo">
         <div className="search-page">
           <h1>Haku</h1>
           <SearchControls scrollToSearchResults={this.scrollToSearchResults} />

--- a/app/containers/UserReservationsPage.js
+++ b/app/containers/UserReservationsPage.js
@@ -6,7 +6,7 @@ import ReservationsList from 'containers/ReservationsList';
 class UserReservationsPage extends Component {
   render() {
     return (
-      <DocumentTitle title="Omat varaukset - Respa">
+      <DocumentTitle title="Omat varaukset - Varaamo">
         <div>
           <h1>Omat varaukset</h1>
           <ReservationsList />

--- a/server/Html.js
+++ b/server/Html.js
@@ -30,7 +30,7 @@ class Html extends Component {
           <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
           <meta content="width=device-width, initial-scale=1" name="viewport" />
           {this.renderStylesLink(appCssSrc, isProduction)}
-          <title>Respa</title>
+          <title>Varaamo</title>
         </head>
         <body>
           <div id="root" />


### PR DESCRIPTION
This PR:
- Changes service name from Respa to Varaamo. (Note that this does not change the repository or folder names.)
- Updates about service texts
- Updates footer texts
- Adds feedback links

Closes #160.
Closes #190.