### PR TITLE
Move reservation info into own component

### DIFF
--- a/app/components/reservation/ReservationInfo.js
+++ b/app/components/reservation/ReservationInfo.js
@@ -1,0 +1,45 @@
+import moment from 'moment';
+import React, { Component, PropTypes } from 'react';
+import { Well } from 'react-bootstrap';
+
+class ReservationInfo extends Component {
+  getMaxPeriodText(maxPeriod) {
+    if (!maxPeriod) {
+      return null;
+    }
+    const asHours = moment.duration(maxPeriod).asHours();
+    return (
+      <p>
+        {`Varauksen maksimipituus: ${asHours} tuntia`}
+      </p>
+    );
+  }
+
+  getMaxReservationsPerUserText(maxReservationsPerUser) {
+    if (!maxReservationsPerUser) {
+      return null;
+    }
+    return (
+      <p>
+        {`Maksimimäärä varauksia per käyttäjä: ${maxReservationsPerUser}`}
+      </p>
+    );
+  }
+
+  render() {
+    const { resource } = this.props;
+
+    return (
+      <Well>
+        {this.getMaxPeriodText(resource.maxPeriod)}
+        {this.getMaxReservationsPerUserText(resource.maxReservationsPerUser)}
+      </Well>
+    );
+  }
+}
+
+ReservationInfo.propTypes = {
+  resource: PropTypes.object.isRequired,
+};
+
+export default ReservationInfo;

--- a/app/containers/ReservationPage.js
+++ b/app/containers/ReservationPage.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import moment from 'moment';
 import React, { Component, PropTypes } from 'react';
 import { Button } from 'react-bootstrap';
 import DocumentTitle from 'react-document-title';
@@ -10,6 +9,7 @@ import { bindActionCreators } from 'redux';
 
 import { fetchResource } from 'actions/resourceActions';
 import ResourceHeader from 'components/resource/ResourceHeader';
+import ReservationInfo from 'components/reservation/ReservationInfo';
 import NotFoundPage from 'containers/NotFoundPage';
 import ReservationForm from 'containers/ReservationForm';
 import reservationPageSelector from 'selectors/containers/reservationPageSelector';
@@ -22,15 +22,6 @@ export class UnconnectedReservationPage extends Component {
     const fetchParams = getDateStartAndEndTimes(date);
 
     actions.fetchResource(id, fetchParams);
-  }
-
-  renderMaxPeriod(maxPeriod) {
-    if (!maxPeriod) {
-      return null;
-    }
-    return (
-      <p>Tämän tilan voi varata enimmillään {moment.duration(maxPeriod).asHours()} tunniksi.</p>
-    );
   }
 
   render() {
@@ -64,7 +55,7 @@ export class UnconnectedReservationPage extends Component {
                 Tilan tiedot
               </Button>
             </LinkContainer>
-            {this.renderMaxPeriod(resource.maxPeriod)}
+            <ReservationInfo resource={resource} />
             <h2>{isLoggedIn ? 'Varaa tila' : 'Varaustilanne'}</h2>
             {!isLoggedIn &&
               <p>Sinun täytyy <a href="/login">kirjautua sisään</a>, jotta voit tehdä varauksen tähän tilaan.</p>

--- a/app/containers/__tests__/ReservationPage.spec.js
+++ b/app/containers/__tests__/ReservationPage.spec.js
@@ -59,6 +59,18 @@ describe('Container: ReservationPage', () => {
     });
   });
 
+  describe('rendering ReservationInfo', () => {
+    it('should render ReservationInfo component', () => {
+      expect(tree.subTree('ReservationInfo')).to.be.ok;
+    });
+
+    it('should pass correct props to ReservationInfo component', () => {
+      const actualProps = tree.subTree('ReservationInfo').props;
+
+      expect(actualProps.resource).to.equal(props.resource);
+    });
+  });
+
   describe('fetching data', () => {
     before(() => {
       const instance = tree.getMountedInstance();


### PR DESCRIPTION
This PR:
- Adds max reservations per user count.
- Makes adding new info about reservating easier in the future.

Closes #197.