### PR TITLE
Fetch search results always on mount

### DIFF
--- a/app/containers/SearchPage.js
+++ b/app/containers/SearchPage.js
@@ -19,9 +19,9 @@ export class UnconnectedSearchPage extends Component {
   }
 
   componentDidMount() {
-    const { actions, filters } = this.props;
+    const { actions, filters, searchDone } = this.props;
     const fetchParams = getFetchParamsFromFilters(filters);
-    if (fetchParams.purpose) {
+    if (searchDone || fetchParams.purpose || fetchParams.people || fetchParams.search) {
       actions.searchResources(fetchParams);
     }
     actions.fetchUnits();


### PR DESCRIPTION
If url contains search parameters always fetch search results when component mounts.
This fixes the issue in #158.

Closes #158.