### PR TITLE
Feature/209 admin edit reservation checks

### DIFF
--- a/app/assets/styles/time-slots.less
+++ b/app/assets/styles/time-slots.less
@@ -84,5 +84,25 @@
         background-color: inherit;
       }
     }
+
+    // Admin styles
+    // ------------
+    &.is-admin {
+      .checkbox-cell {
+        width: 50px;
+      }
+
+      .time-cell {
+        width: 120px;
+      }
+
+      .status-cell {
+        width: 80px;
+      }
+
+      .controls-cell {
+        width: 140px;
+      }
+    }
   }
 }

--- a/app/components/reservation/TimeSlot.js
+++ b/app/components/reservation/TimeSlot.js
@@ -150,18 +150,18 @@ class TimeSlot extends Component {
             {slot.asString}
           </time>
         </td>
-        <td>
+        <td className="status-cell">
           <Label bsStyle={labelBsStyle}>
             {labelText}
           </Label>
         </td>
         {isAdmin && (
-          <td>{reservation && slot.reservationStarting && this.renderUserInfo(reservation.user)}</td>
+          <td className="user-cell">{reservation && slot.reservationStarting && this.renderUserInfo(reservation.user)}</td>
         )}
         {isAdmin && (
-          <td>{reservation && slot.reservationStarting && reservation.comments}</td>)}
+          <td className="comments-cell">{reservation && slot.reservationStarting && reservation.comments}</td>)}
         {isAdmin && (
-          <td>
+          <td className="controls-cell">
             {reservation && slot.reservationStarting && !isEditing && (
               <ReservationControls
                 onDeleteClick={this.handleDeleteClick}

--- a/app/components/reservation/TimeSlot.js
+++ b/app/components/reservation/TimeSlot.js
@@ -99,6 +99,7 @@ class TimeSlot extends Component {
 
   render() {
     const {
+      isEditing,
       isLoggedIn,
       resource,
       selected,
@@ -161,7 +162,7 @@ class TimeSlot extends Component {
           <td>{reservation && slot.reservationStarting && reservation.comments}</td>)}
         {isAdmin && (
           <td>
-            {slot.reservationStarting && (
+            {reservation && slot.reservationStarting && !isEditing && (
               <ReservationControls
                 onDeleteClick={this.handleDeleteClick}
                 onEditClick={this.handleEditClick}
@@ -177,6 +178,7 @@ class TimeSlot extends Component {
 
 TimeSlot.propTypes = {
   addNotification: PropTypes.func.isRequired,
+  isEditing: PropTypes.bool.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,
   openReservationDeleteModal: PropTypes.func.isRequired,

--- a/app/components/reservation/TimeSlots.js
+++ b/app/components/reservation/TimeSlots.js
@@ -14,6 +14,7 @@ class TimeSlots extends Component {
   renderTimeSlot(slot) {
     const {
       addNotification,
+      isEditing,
       isLoggedIn,
       onClick,
       openReservationDeleteModal,
@@ -29,6 +30,7 @@ class TimeSlots extends Component {
     return (
       <TimeSlot
         addNotification={addNotification}
+        isEditing={isEditing}
         isLoggedIn={isLoggedIn}
         key={slot.start}
         onClick={onClick}
@@ -83,6 +85,7 @@ class TimeSlots extends Component {
 
 TimeSlots.propTypes = {
   addNotification: PropTypes.func.isRequired,
+  isEditing: PropTypes.bool.isRequired,
   isFetching: PropTypes.bool.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,

--- a/app/components/reservation/__tests__/TimeSlot.spec.js
+++ b/app/components/reservation/__tests__/TimeSlot.spec.js
@@ -13,6 +13,7 @@ import Resource from 'fixtures/Resource';
 function getProps(props) {
   const defaults = {
     addNotification: simple.stub(),
+    isEditing: true,
     isLoggedIn: true,
     onClick: simple.stub(),
     openReservationDeleteModal: simple.stub(),

--- a/app/components/reservation/__tests__/TimeSlots.spec.js
+++ b/app/components/reservation/__tests__/TimeSlots.spec.js
@@ -17,6 +17,7 @@ describe('Component: reservation/TimeSlots', () => {
     ];
     const props = {
       addNotification: simple.stub(),
+      isEditing: false,
       isFetching: false,
       isLoggedIn: true,
       onClick: simple.stub(),
@@ -78,6 +79,7 @@ describe('Component: reservation/TimeSlots', () => {
       it('should pass correct props to TimeSlots', () => {
         timeSlotTrees.forEach((timeSlotTree, index) => {
           expect(timeSlotTree.props.addNotification).to.equal(props.addNotification);
+          expect(timeSlotTree.props.isEditing).to.equal(props.isEditing);
           expect(timeSlotTree.props.isLoggedIn).to.equal(props.isLoggedIn);
           expect(timeSlotTree.props.onClick).to.equal(props.onClick);
           expect(timeSlotTree.props.openReservationDeleteModal).to.equal(props.openReservationDeleteModal);
@@ -99,6 +101,7 @@ describe('Component: reservation/TimeSlots', () => {
   describe('without timeslots', () => {
     const props = {
       addNotification: simple.stub(),
+      isEditing: false,
       isFetching: false,
       isLoggedIn: true,
       onClick: simple.stub(),

--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -135,6 +135,7 @@ export class UnconnectedReservationForm extends Component {
         />
         <TimeSlots
           addNotification={actions.addNotification}
+          isEditing={isEditing}
           isFetching={isFetchingResource}
           isLoggedIn={isLoggedIn}
           onClick={actions.toggleTimeSlot}

--- a/app/containers/__tests__/ReservationForm.spec.js
+++ b/app/containers/__tests__/ReservationForm.spec.js
@@ -111,6 +111,7 @@ describe('Container: ReservationForm', () => {
         const actualProps = timeSlotsTrees[0].props;
 
         expect(actualProps.addNotification).to.deep.equal(props.actions.addNotification);
+        expect(actualProps.isEditing).to.exist;
         expect(actualProps.isFetching).to.equal(props.isFetchingResource);
         expect(actualProps.isLoggedIn).to.equal(props.isLoggedIn);
         expect(actualProps.onClick).to.deep.equal(props.actions.toggleTimeSlot);

--- a/app/reducers/__tests__/reservationReducer.spec.js
+++ b/app/reducers/__tests__/reservationReducer.spec.js
@@ -168,7 +168,7 @@ describe('Reducer: reservationReducer', () => {
     });
 
     describe('UI.SELECT_RESERVATION_TO_EDIT', () => {
-      it('should add the given reservation to toEdit', () => {
+      it('should set the given reservation to toEdit', () => {
         const initialState = Immutable({
           selected: [],
           toEdit: [],
@@ -181,7 +181,7 @@ describe('Reducer: reservationReducer', () => {
         expect(nextState.toEdit).to.deep.equal(expected);
       });
 
-      it('should not affect other reservations in toEdit', () => {
+      it('should remove other reservations in toEdit', () => {
         const reservations = [
           Reservation.build(),
           Reservation.build(),
@@ -192,7 +192,7 @@ describe('Reducer: reservationReducer', () => {
         });
         const action = selectReservationToEdit({ reservation: reservations[1] });
         const nextState = reservationReducer(initialState, action);
-        const expected = Immutable([reservations[0], reservations[1]]);
+        const expected = Immutable([reservations[1]]);
 
         expect(nextState.toEdit).to.deep.equal(expected);
       });

--- a/app/reducers/reservationReducer.js
+++ b/app/reducers/reservationReducer.js
@@ -19,8 +19,8 @@ function selectReservationToEdit(state, action) {
   );
 
   return state.merge({
-    selected: [...state.selected, ...selected],
-    toEdit: [...state.toEdit, reservation],
+    selected,
+    toEdit: [reservation],
   });
 }
 


### PR DESCRIPTION
This PR:
- Makes sure admins can only edit one reservation at a time.
- Hides reservation controls when admin is editing a reservation.
- Improves admin reservation table styles.

Closes #209.
