### PR TITLE
Store date in url in resource page

### DIFF
--- a/app/components/search/SearchResult.js
+++ b/app/components/search/SearchResult.js
@@ -36,12 +36,18 @@ class SearchResult extends Component {
     return (
       <tr>
         <td style={{ height: '80px', width: '80px' }}>
-          <Link to={`/resources/${result.id}`}>
+          <Link
+            to={`/resources/${result.id}`}
+            query={{ date: date.split('T')[0] }}
+          >
             {this.renderImage(getMainImage(result.images))}
           </Link>
         </td>
         <td>
-          <Link to={`/resources/${result.id}`}>
+          <Link
+            to={`/resources/${result.id}`}
+            query={{ date: date.split('T')[0] }}
+          >
             <h4>{getName(result)}</h4>
             <div className="unit-name">{getName(unit)}</div>
           </Link>

--- a/app/containers/ReservationPage.js
+++ b/app/containers/ReservationPage.js
@@ -35,6 +35,7 @@ export class UnconnectedReservationPage extends Component {
 
   render() {
     const {
+      date,
       id,
       isFetchingResource,
       isLoggedIn,
@@ -57,7 +58,7 @@ export class UnconnectedReservationPage extends Component {
               address={getAddressWithName(unit)}
               name={resourceName}
             />
-            <LinkContainer to={`/resources/${id}`}>
+            <LinkContainer to={`/resources/${id}?date=${date.split('T')[0]}`}>
               <Button
                 bsSize="large"
                 bsStyle="primary"

--- a/app/containers/ResourcePage.js
+++ b/app/containers/ResourcePage.js
@@ -28,6 +28,7 @@ export class UnconnectedResourcePage extends Component {
 
   render() {
     const {
+      date,
       id,
       isFetchingResource,
       isLoggedIn,
@@ -48,7 +49,7 @@ export class UnconnectedResourcePage extends Component {
               address={getAddressWithName(unit)}
               name={resourceName}
             />
-            <LinkContainer to={`/resources/${id}/reservation`}>
+            <LinkContainer to={`/resources/${id}/reservation?date=${date.split('T')[0]}`}>
               <Button
                 bsSize="large"
                 bsStyle="primary"
@@ -75,6 +76,7 @@ export class UnconnectedResourcePage extends Component {
 
 UnconnectedResourcePage.propTypes = {
   actions: PropTypes.object.isRequired,
+  date: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   isFetchingResource: PropTypes.bool.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,

--- a/app/containers/__tests__/ReservationPage.spec.js
+++ b/app/containers/__tests__/ReservationPage.spec.js
@@ -28,7 +28,7 @@ describe('Container: ReservationPage', () => {
     const linkTree = tree.subTree('LinkContainer');
 
     it('should display a link to this resources page', () => {
-      const expected = `/resources/${props.resource.id}`;
+      const expected = `/resources/${props.resource.id}?date=${props.date}`;
 
       expect(linkTree.props.to).to.equal(expected);
     });

--- a/app/containers/__tests__/ResourcePage.spec.js
+++ b/app/containers/__tests__/ResourcePage.spec.js
@@ -17,6 +17,7 @@ describe('Container: ResourcePage', () => {
   });
   const props = {
     actions: { fetchResource: simple.stub() },
+    date: '2015-12-12',
     id: resource.id,
     isFetchingResource: false,
     isLoggedIn: true,
@@ -29,7 +30,7 @@ describe('Container: ResourcePage', () => {
     const linkTree = tree.subTree('LinkContainer');
 
     it('should display a link to this resources reservation page', () => {
-      const expected = `/resources/${props.resource.id}/reservation`;
+      const expected = `/resources/${props.resource.id}/reservation?date=${props.date}`;
 
       expect(linkTree.props.to).to.equal(expected);
     });

--- a/app/selectors/containers/__tests__/resourcePageSelector.spec.js
+++ b/app/selectors/containers/__tests__/resourcePageSelector.spec.js
@@ -26,7 +26,9 @@ function getState(resources = [], units = []) {
 function getProps(id = 'some-id') {
   return {
     location: {
-      query: {},
+      query: {
+        date: '2015-12-12',
+      },
     },
     params: {
       id,
@@ -35,6 +37,15 @@ function getProps(id = 'some-id') {
 }
 
 describe('Selector: resourcePageSelector', () => {
+  it('should return the date in props.location.date', () => {
+    const state = getState();
+    const props = getProps();
+    const selected = resourcePageSelector(state, props);
+    const expected = props.location.query.date;
+
+    expect(selected.date).to.equal(expected);
+  });
+
   it('should return the id in router.params.id', () => {
     const state = getState();
     const props = getProps();

--- a/app/selectors/containers/resourcePageSelector.js
+++ b/app/selectors/containers/resourcePageSelector.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 
 import ActionTypes from 'constants/ActionTypes';
+import dateSelector from 'selectors/dateSelector';
 import isLoggedInSelector from 'selectors/isLoggedInSelector';
 import resourceSelector from 'selectors/resourceSelector';
 import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
@@ -9,12 +10,14 @@ const idSelector = (state, props) => props.params.id;
 const unitsSelector = (state) => state.data.units;
 
 const resourcePageSelector = createSelector(
+  dateSelector,
   idSelector,
   isLoggedInSelector,
   requestIsActiveSelectorFactory(ActionTypes.API.RESOURCE_GET_REQUEST),
   resourceSelector,
   unitsSelector,
   (
+    date,
     id,
     isLoggedIn,
     isFetchingResource,
@@ -24,6 +27,7 @@ const resourcePageSelector = createSelector(
     const unit = units[resource.unit] || {};
 
     return {
+      date,
       id,
       isFetchingResource,
       isLoggedIn,


### PR DESCRIPTION
Allows user to switch between search, resource and reservation
pages without losing the chosen date.
Closes #224.