### PR TITLE
Use real reservation states

### DIFF
--- a/app/assets/styles/reservations-list.less
+++ b/app/assets/styles/reservations-list.less
@@ -66,7 +66,7 @@
       }
     }
 
-    .status {
+    .state {
       font-size: 20px;
       width: 100%;
       max-width: 330px;

--- a/app/components/reservation/ReservationControls.js
+++ b/app/components/reservation/ReservationControls.js
@@ -6,15 +6,6 @@ class ReservationControls extends Component {
   constructor(props) {
     super(props);
     this.buttons = {
-      accept: (
-        <Button
-          bsSize="xsmall"
-          bsStyle="success"
-          key="acceptButton"
-        >
-          Hyväksy
-        </Button>
-      ),
       adminCancel: (
         <Button
           bsSize="xsmall"
@@ -34,13 +25,13 @@ class ReservationControls extends Component {
           Peru
         </Button>
       ),
-      decline: (
+      confirm: (
         <Button
           bsSize="xsmall"
-          bsStyle="danger"
-          key="declineButton"
+          bsStyle="success"
+          key="confirmButton"
         >
-          Hylkää
+          Hyväksy
         </Button>
       ),
       delete: (
@@ -51,6 +42,15 @@ class ReservationControls extends Component {
           onClick={props.onDeleteClick}
         >
           Poista
+        </Button>
+      ),
+      deny: (
+        <Button
+          bsSize="xsmall"
+          bsStyle="danger"
+          key="denyButton"
+        >
+          Hylkää
         </Button>
       ),
       edit: (
@@ -66,20 +66,20 @@ class ReservationControls extends Component {
     };
   }
 
-  renderButtons(buttons, isAdmin, status) {
-    switch (status) {
+  renderButtons(buttons, isAdmin, state) {
+    switch (state) {
 
-    case 'accepted':
+    case 'cancelled':
+      return isAdmin ? null : null;
+
+    case 'confirmed':
       return isAdmin ? [buttons.adminCancel] : [buttons.cancel];
 
-    case 'canceled':
+    case 'denied':
       return isAdmin ? null : null;
 
-    case 'declined':
-      return isAdmin ? null : null;
-
-    case 'pending':
-      return isAdmin ? [buttons.accept, buttons.decline] : [buttons.edit, buttons.cancel];
+    case 'requested':
+      return isAdmin ? [buttons.confirm, buttons.deny] : [buttons.edit, buttons.cancel];
 
     default:
       return isAdmin ? [buttons.edit, buttons.delete] : [buttons.edit, buttons.delete];
@@ -96,7 +96,7 @@ class ReservationControls extends Component {
 
     return (
       <div className="buttons">
-        {this.renderButtons(this.buttons, isAdmin, reservation.status)}
+        {this.renderButtons(this.buttons, isAdmin, reservation.state)}
       </div>
     );
   }

--- a/app/components/reservation/ReservationControls.js
+++ b/app/components/reservation/ReservationControls.js
@@ -66,8 +66,12 @@ class ReservationControls extends Component {
     };
   }
 
-  renderButtons(buttons, isAdmin, state) {
-    switch (state) {
+  renderButtons(buttons, isAdmin, reservation) {
+    if (!reservation.needManualConfirmation) {
+      return isAdmin ? [buttons.edit, buttons.delete] : [buttons.edit, buttons.delete];
+    }
+
+    switch (reservation.state) {
 
     case 'cancelled':
       return isAdmin ? null : null;
@@ -82,7 +86,7 @@ class ReservationControls extends Component {
       return isAdmin ? [buttons.confirm, buttons.deny] : [buttons.edit, buttons.cancel];
 
     default:
-      return isAdmin ? [buttons.edit, buttons.delete] : [buttons.edit, buttons.delete];
+      return null;
 
     }
   }
@@ -96,7 +100,7 @@ class ReservationControls extends Component {
 
     return (
       <div className="buttons">
-        {this.renderButtons(this.buttons, isAdmin, reservation.state)}
+        {this.renderButtons(this.buttons, isAdmin, reservation)}
       </div>
     );
   }

--- a/app/components/reservation/ReservationsListItem.js
+++ b/app/components/reservation/ReservationsListItem.js
@@ -7,12 +7,11 @@ import { Link } from 'react-router';
 
 import TimeRange from 'components/common/TimeRange';
 import ReservationControls from 'components/reservation/ReservationControls';
-import { RESERVATION_STATUS_LABELS } from 'constants/AppConstants';
+import { RESERVATION_STATE_LABELS } from 'constants/AppConstants';
 import {
   getCaption,
   getMainImage,
   getName,
-  getReservationStatus,
 } from 'utils/DataUtils';
 
 class ReservationsListItem extends Component {
@@ -69,17 +68,15 @@ class ReservationsListItem extends Component {
     return null;
   }
 
-  renderStatusLabel(reservation) {
-    const status = getReservationStatus(reservation);
-
-    if (!status) {
+  renderStateLabel(reservation) {
+    if (!reservation.needManualConfirmation) {
       return null;
     }
 
-    const { labelBsStyle, labelText } = RESERVATION_STATUS_LABELS[status];
+    const { labelBsStyle, labelText } = RESERVATION_STATE_LABELS[reservation.state];
 
     return (
-      <div className="status">
+      <div className="state">
         <Label bsStyle={labelBsStyle}>{labelText}</Label>
       </div>
     );
@@ -144,9 +141,9 @@ class ReservationsListItem extends Component {
           onCancelClick={this.handleCancelClick}
           onDeleteClick={this.handleDeleteClick}
           onEditClick={this.handleEditClick}
-          reservation={Object.assign({}, reservation, { status: getReservationStatus(reservation) })}
+          reservation={reservation}
         />
-        {this.renderStatusLabel(reservation)}
+      {this.renderStateLabel(reservation)}
       </li>
     );
   }

--- a/app/components/reservation/__tests__/ReservationControls.spec.js
+++ b/app/components/reservation/__tests__/ReservationControls.spec.js
@@ -14,13 +14,13 @@ describe('Component: reservation/ReservationControls', () => {
   const onDeleteClick = simple.stub();
   const onEditClick = simple.stub();
 
-  function getWrapper(reservationStatus = null, isAdmin = false) {
+  function getWrapper(reservationState = null, isAdmin = false) {
     const props = {
       isAdmin,
       onCancelClick,
       onDeleteClick,
       onEditClick,
-      reservation: Immutable(Reservation.build({ status: reservationStatus })),
+      reservation: Immutable(Reservation.build({ state: reservationState })),
     };
     return shallow(<ReservationControls {...props} />);
   }
@@ -63,8 +63,8 @@ describe('Component: reservation/ReservationControls', () => {
     });
   });
 
-  describe('with preliminary reservation in pending state', () => {
-    const buttons = getWrapper('pending').find(Button);
+  describe('with preliminary reservation in requested state', () => {
+    const buttons = getWrapper('requested').find(Button);
 
     it('should render two buttons', () => {
       expect(buttons.length).to.equal(2);
@@ -101,24 +101,24 @@ describe('Component: reservation/ReservationControls', () => {
     });
   });
 
-  describe('with preliminary reservation in canceled state', () => {
-    const buttons = getWrapper('canceled').find(Button);
+  describe('with preliminary reservation in cancelled state', () => {
+    const buttons = getWrapper('cancelled').find(Button);
 
     it('should not render any buttons', () => {
       expect(buttons.length).to.equal(0);
     });
   });
 
-  describe('with preliminary reservation in declined state', () => {
-    const buttons = getWrapper('declined').find(Button);
+  describe('with preliminary reservation in denied state', () => {
+    const buttons = getWrapper('denied').find(Button);
 
     it('should not render any buttons', () => {
       expect(buttons.length).to.equal(0);
     });
   });
 
-  describe('with preliminary reservation in accepted state', () => {
-    const buttons = getWrapper('accepted').find(Button);
+  describe('with preliminary reservation in confirmed state', () => {
+    const buttons = getWrapper('confirmed').find(Button);
 
     it('should render one button', () => {
       expect(buttons.length).to.equal(1);

--- a/app/components/reservation/__tests__/ReservationControls.spec.js
+++ b/app/components/reservation/__tests__/ReservationControls.spec.js
@@ -14,128 +14,240 @@ describe('Component: reservation/ReservationControls', () => {
   const onDeleteClick = simple.stub();
   const onEditClick = simple.stub();
 
-  function getWrapper(reservationState = null, isAdmin = false) {
+  function getWrapper(reservation, isAdmin = false) {
     const props = {
       isAdmin,
       onCancelClick,
       onDeleteClick,
       onEditClick,
-      reservation: Immutable(Reservation.build({ state: reservationState })),
+      reservation: Immutable(reservation),
     };
     return shallow(<ReservationControls {...props} />);
   }
 
-  describe('with normal reservation', () => {
-    const buttons = getWrapper().find(Button);
+  describe('if isAdmin is true', () => {
+    const isAdmin = true;
 
-    it('should render two buttons', () => {
-      expect(buttons.length).to.equal(2);
+    describe('with regular reservation', () => {
+      const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed' });
+      const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+      it('should render two buttons', () => {
+        expect(buttons.length).to.equal(2);
+      });
+
+      describe('the first button', () => {
+        const button = buttons.at(0);
+
+        it('should be an edit button', () => {
+          expect(button.props().children).to.equal('Muokkaa');
+        });
+
+        it('clicking the button should call onEditClick', () => {
+          onEditClick.reset();
+          button.props().onClick();
+
+          expect(onEditClick.callCount).to.equal(1);
+        });
+      });
+
+      describe('the second button', () => {
+        const button = buttons.at(1);
+
+        it('should be a delete button', () => {
+          expect(button.props().children).to.equal('Poista');
+        });
+
+        it('clicking the button should call onDeleteClick', () => {
+          onDeleteClick.reset();
+          button.props().onClick();
+
+          expect(onDeleteClick.callCount).to.equal(1);
+        });
+      });
     });
 
-    describe('the first button', () => {
-      const button = buttons.at(0);
+    describe('with preliminary reservation in requested state', () => {
+      const reservation = Reservation.build({ needManualConfirmation: true, state: 'requested' });
+      const buttons = getWrapper(reservation, isAdmin).find(Button);
 
-      it('should be an edit button', () => {
-        expect(button.props().children).to.equal('Muokkaa');
+      it('should render two buttons', () => {
+        expect(buttons.length).to.equal(2);
       });
 
-      it('clicking the button should call onEditClick', () => {
-        onEditClick.reset();
-        button.props().onClick();
+      describe('the first button', () => {
+        const button = buttons.at(0);
 
-        expect(onEditClick.callCount).to.equal(1);
+        it('should be a confirm button', () => {
+          expect(button.props().children).to.equal('Hyväksy');
+        });
+      });
+
+      describe('the second button', () => {
+        const button = buttons.at(1);
+
+        it('should be a deny button', () => {
+          expect(button.props().children).to.equal('Hylkää');
+        });
       });
     });
 
-    describe('the second button', () => {
-      const button = buttons.at(1);
+    describe('with preliminary reservation in cancelled state', () => {
+      const reservation = Reservation.build({ needManualConfirmation: true, state: 'cancelled' });
+      const buttons = getWrapper(reservation, isAdmin).find(Button);
 
-      it('should be a delete button', () => {
-        expect(button.props().children).to.equal('Poista');
+      it('should not render any buttons', () => {
+        expect(buttons.length).to.equal(0);
+      });
+    });
+
+    describe('with preliminary reservation in denied state', () => {
+      const reservation = Reservation.build({ needManualConfirmation: true, state: 'denied' });
+      const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+      it('should not render any buttons', () => {
+        expect(buttons.length).to.equal(0);
+      });
+    });
+
+    describe('with preliminary reservation in confirmed state', () => {
+      const reservation = Reservation.build({ needManualConfirmation: true, state: 'confirmed' });
+      const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+      it('should render one button', () => {
+        expect(buttons.length).to.equal(1);
       });
 
-      it('clicking the button should call onDeleteClick', () => {
-        onDeleteClick.reset();
-        button.props().onClick();
+      describe('the button', () => {
+        const button = buttons.at(0);
 
-        expect(onDeleteClick.callCount).to.equal(1);
+        it('should be a cancel button', () => {
+          expect(button.props().children).to.equal('Peru');
+        });
       });
     });
   });
 
-  describe('with preliminary reservation in requested state', () => {
-    const buttons = getWrapper('requested').find(Button);
+  describe('if isAdmin is false', () => {
+    const isAdmin = false;
 
-    it('should render two buttons', () => {
-      expect(buttons.length).to.equal(2);
-    });
+    describe('with regular reservation', () => {
+      const reservation = Reservation.build({ needManualConfirmation: false, state: 'confirmed' });
+      const buttons = getWrapper(reservation, isAdmin).find(Button);
 
-    describe('the first button', () => {
-      const button = buttons.at(0);
-
-      it('should be an edit button', () => {
-        expect(button.props().children).to.equal('Muokkaa');
+      it('should render two buttons', () => {
+        expect(buttons.length).to.equal(2);
       });
 
-      it('clicking the button should call onEditClick', () => {
-        onEditClick.reset();
-        button.props().onClick();
+      describe('the first button', () => {
+        const button = buttons.at(0);
 
-        expect(onEditClick.callCount).to.equal(1);
+        it('should be an edit button', () => {
+          expect(button.props().children).to.equal('Muokkaa');
+        });
+
+        it('clicking the button should call onEditClick', () => {
+          onEditClick.reset();
+          button.props().onClick();
+
+          expect(onEditClick.callCount).to.equal(1);
+        });
+      });
+
+      describe('the second button', () => {
+        const button = buttons.at(1);
+
+        it('should be a delete button', () => {
+          expect(button.props().children).to.equal('Poista');
+        });
+
+        it('clicking the button should call onDeleteClick', () => {
+          onDeleteClick.reset();
+          button.props().onClick();
+
+          expect(onDeleteClick.callCount).to.equal(1);
+        });
       });
     });
 
-    describe('the second button', () => {
-      const button = buttons.at(1);
+    describe('with preliminary reservation in requested state', () => {
+      const reservation = Reservation.build({ needManualConfirmation: true, state: 'requested' });
+      const buttons = getWrapper(reservation, isAdmin).find(Button);
 
-      it('should be a cancel button', () => {
-        expect(button.props().children).to.equal('Peru');
+      it('should render two buttons', () => {
+        expect(buttons.length).to.equal(2);
       });
 
-      it('clicking the button should call onCancelClick', () => {
-        onCancelClick.reset();
-        button.props().onClick();
+      describe('the first button', () => {
+        const button = buttons.at(0);
 
-        expect(onCancelClick.callCount).to.equal(1);
-      });
-    });
-  });
+        it('should be an edit button', () => {
+          expect(button.props().children).to.equal('Muokkaa');
+        });
 
-  describe('with preliminary reservation in cancelled state', () => {
-    const buttons = getWrapper('cancelled').find(Button);
+        it('clicking the button should call onEditClick', () => {
+          onEditClick.reset();
+          button.props().onClick();
 
-    it('should not render any buttons', () => {
-      expect(buttons.length).to.equal(0);
-    });
-  });
-
-  describe('with preliminary reservation in denied state', () => {
-    const buttons = getWrapper('denied').find(Button);
-
-    it('should not render any buttons', () => {
-      expect(buttons.length).to.equal(0);
-    });
-  });
-
-  describe('with preliminary reservation in confirmed state', () => {
-    const buttons = getWrapper('confirmed').find(Button);
-
-    it('should render one button', () => {
-      expect(buttons.length).to.equal(1);
-    });
-
-    describe('the button', () => {
-      const button = buttons.at(0);
-
-      it('should be a cancel button', () => {
-        expect(button.props().children).to.equal('Peru');
+          expect(onEditClick.callCount).to.equal(1);
+        });
       });
 
-      it('clicking the button should call onCancelClick', () => {
-        onCancelClick.reset();
-        button.props().onClick();
+      describe('the second button', () => {
+        const button = buttons.at(1);
 
-        expect(onCancelClick.callCount).to.equal(1);
+        it('should be a cancel button', () => {
+          expect(button.props().children).to.equal('Peru');
+        });
+
+        it('clicking the button should call onCancelClick', () => {
+          onCancelClick.reset();
+          button.props().onClick();
+
+          expect(onCancelClick.callCount).to.equal(1);
+        });
+      });
+    });
+
+    describe('with preliminary reservation in cancelled state', () => {
+      const reservation = Reservation.build({ needManualConfirmation: true, state: 'cancelled' });
+      const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+      it('should not render any buttons', () => {
+        expect(buttons.length).to.equal(0);
+      });
+    });
+
+    describe('with preliminary reservation in denied state', () => {
+      const reservation = Reservation.build({ needManualConfirmation: true, state: 'denied' });
+      const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+      it('should not render any buttons', () => {
+        expect(buttons.length).to.equal(0);
+      });
+    });
+
+    describe('with preliminary reservation in confirmed state', () => {
+      const reservation = Reservation.build({ needManualConfirmation: true, state: 'confirmed' });
+      const buttons = getWrapper(reservation, isAdmin).find(Button);
+
+      it('should render one button', () => {
+        expect(buttons.length).to.equal(1);
+      });
+
+      describe('the button', () => {
+        const button = buttons.at(0);
+
+        it('should be a cancel button', () => {
+          expect(button.props().children).to.equal('Peru');
+        });
+
+        it('clicking the button should call onCancelClick', () => {
+          onCancelClick.reset();
+          button.props().onClick();
+
+          expect(onCancelClick.callCount).to.equal(1);
+        });
       });
     });
   });

--- a/app/components/reservation/__tests__/ReservationsListItem.spec.js
+++ b/app/components/reservation/__tests__/ReservationsListItem.spec.js
@@ -93,8 +93,7 @@ describe('Component: reservation/ReservationsListItem', () => {
       it('should pass correct props to ReservationControls component', () => {
         const actualProps = reservationControlsTree.props;
 
-        // TODO: This should be uncommented once API returned reservations contain status field.
-        // expect(actualProps.reservation).to.equal(props.reservation);
+        expect(actualProps.reservation).to.equal(props.reservation);
         expect(actualProps.isAdmin).to.equal(false);
         expect(actualProps.onCancelClick).to.equal(instance.handleCancelClick);
         expect(actualProps.onDeleteClick).to.equal(instance.handleDeleteClick);

--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -13,20 +13,20 @@ export default {
     'Accept-Language': 'fi',
     'Content-Type': 'application/json',
   },
-  RESERVATION_STATUS_LABELS: {
-    accepted: {
-      labelBsStyle: 'success',
-      labelText: 'Hyväksytty',
-    },
-    canceled: {
+  RESERVATION_STATE_LABELS: {
+    cancelled: {
       labelBsStyle: 'default',
       labelText: 'Peruttu',
     },
-    declined: {
+    confirmed: {
+      labelBsStyle: 'success',
+      labelText: 'Hyväksytty',
+    },
+    denied: {
       labelBsStyle: 'danger',
       labelText: 'Hylätty',
     },
-    pending: {
+    requested: {
       labelBsStyle: 'primary',
       labelText: 'Käsiteltävänä',
     },

--- a/app/containers/ReservationCancelModal.js
+++ b/app/containers/ReservationCancelModal.js
@@ -8,7 +8,7 @@ import { bindActionCreators } from 'redux';
 import { closeReservationCancelModal } from 'actions/uiActions';
 import TimeRange from 'components/common/TimeRange';
 import reservationCancelModalSelector from 'selectors/containers/reservationCancelModalSelector';
-import { getName, getReservationStatus } from 'utils/DataUtils';
+import { getName } from 'utils/DataUtils';
 
 export class UnconnectedReservationCancelModal extends Component {
   constructor(props) {
@@ -21,8 +21,8 @@ export class UnconnectedReservationCancelModal extends Component {
     this.props.actions.closeReservationCancelModal();
   }
 
-  renderModalContent(status, reservationsToCancel) {
-    if (status === 'accepted') {
+  renderModalContent(state, reservationsToCancel) {
+    if (state === 'confirmed') {
       return (
         <div>
           <p>
@@ -72,7 +72,7 @@ export class UnconnectedReservationCancelModal extends Component {
       show,
     } = this.props;
 
-    const status = getReservationStatus(reservationsToCancel[0]);
+    const state = reservationsToCancel.length ? reservationsToCancel[0].state : '';
 
     return (
       <Modal
@@ -81,12 +81,12 @@ export class UnconnectedReservationCancelModal extends Component {
       >
         <Modal.Header closeButton>
           <Modal.Title>
-            {status === 'accepted' ? 'Varauksen peruminen' : 'Varauksen perumisen vahvistus'}
+            {state === 'confirmed' ? 'Varauksen peruminen' : 'Varauksen perumisen vahvistus'}
           </Modal.Title>
         </Modal.Header>
 
         <Modal.Body>
-          {this.renderModalContent(status, reservationsToCancel)}
+          {this.renderModalContent(state, reservationsToCancel)}
         </Modal.Body>
 
         <Modal.Footer>
@@ -94,9 +94,9 @@ export class UnconnectedReservationCancelModal extends Component {
             bsStyle="default"
             onClick={actions.closeReservationCancelModal}
           >
-            {status === 'accepted' ? 'Takaisin' : 'Älä peruuta varausta'}
+            {state === 'confirmed' ? 'Takaisin' : 'Älä peruuta varausta'}
           </Button>
-          {status !== 'accepted' && (
+          {state !== 'confirmed' && (
             <Button
               bsStyle="danger"
               onClick={this.handleCancel}

--- a/app/containers/__tests__/ReservationCancelModal.spec.js
+++ b/app/containers/__tests__/ReservationCancelModal.spec.js
@@ -4,7 +4,6 @@ import simple from 'simple-mock';
 import sd from 'skin-deep';
 
 import Immutable from 'seamless-immutable';
-import DataUtils from 'utils/DataUtils';
 
 import {
   UnconnectedReservationCancelModal as ReservationCancelModal,
@@ -28,13 +27,26 @@ describe('Container: ReservationCancelModal', () => {
     }),
   };
 
+  function getExtraProps(reservationState) {
+    return {
+      reservationsToCancel: Immutable([
+        Reservation.build({ resource: resource.id, state: reservationState }),
+        Reservation.build({ resource: resource.id, state: reservationState }),
+      ]),
+      resources: Immutable({
+        [resource.id]: resource,
+      }),
+    };
+  }
+
   function getTree(extraProps = {}) {
     return sd.shallowRender(<ReservationCancelModal {...Object.assign({}, props, extraProps)} />);
   }
 
   describe('render', () => {
-    describe('when reservation status is anything but "accepted"', () => {
-      const tree = getTree();
+    describe('when reservation state is anything but "confirmed"', () => {
+      const extraProps = getExtraProps('requested');
+      const tree = getTree(extraProps);
       const instance = tree.getMountedInstance();
 
       it('should render a Modal component', () => {
@@ -137,13 +149,9 @@ describe('Container: ReservationCancelModal', () => {
       });
     });
 
-    describe('when reservation status is "accepted"', () => {
-      simple.mock(DataUtils, 'getReservationStatus').returnWith('accepted');
-      const tree = getTree();
-
-      after(() => {
-        simple.restore();
-      });
+    describe('when reservation state is "confirmed"', () => {
+      const extraProps = getExtraProps('confirmed');
+      const tree = getTree(extraProps);
 
       it('should render a Modal component', () => {
         const modalTrees = tree.everySubTree('Modal');

--- a/app/selectors/__tests__/sortedReservationsSelector.spec.js
+++ b/app/selectors/__tests__/sortedReservationsSelector.spec.js
@@ -62,8 +62,8 @@ describe('Selector: sortedReservationsSelector', () => {
 
     it('should return only preliminary reservations when filter is "preliminary"', () => {
       const reservations = [
-        Reservation.build({ id: 1 }),
-        Reservation.build({ id: 4 }),
+        Reservation.build({ needManualConfirmation: true }),
+        Reservation.build({ needManualConfirmation: false }),
       ];
       const state = getState(reservations);
       const props = { filter: 'preliminary' };
@@ -74,8 +74,8 @@ describe('Selector: sortedReservationsSelector', () => {
 
     it('should return only regular reservations when filter is "regular"', () => {
       const reservations = [
-        Reservation.build({ id: 1 }),
-        Reservation.build({ id: 4 }),
+        Reservation.build({ needManualConfirmation: true }),
+        Reservation.build({ needManualConfirmation: false }),
       ];
       const state = getState(reservations);
       const props = { filter: 'regular' };
@@ -86,8 +86,8 @@ describe('Selector: sortedReservationsSelector', () => {
 
     it('should return all reservations when filter is anything else', () => {
       const reservations = [
-        Reservation.build({ id: 1 }),
-        Reservation.build({ id: 4 }),
+        Reservation.build({ needManualConfirmation: true }),
+        Reservation.build({ needManualConfirmation: false }),
       ];
       const state = getState(reservations);
       const props = { filter: 'whatever' };
@@ -98,9 +98,9 @@ describe('Selector: sortedReservationsSelector', () => {
 
     it('should return the results ordered from oldest to newest', () => {
       const reservations = [
-        Reservation.build({ begin: '2015-10-10', id: 1 }),
-        Reservation.build({ begin: '2015-09-20', id: 2 }),
-        Reservation.build({ begin: '2015-10-30', id: 3 }),
+        Reservation.build({ begin: '2015-10-10', needManualConfirmation: true }),
+        Reservation.build({ begin: '2015-09-20', needManualConfirmation: true }),
+        Reservation.build({ begin: '2015-10-30', needManualConfirmation: true }),
       ];
       const state = getState(reservations);
       const props = { filter: 'preliminary' };

--- a/app/selectors/sortedReservationsSelector.js
+++ b/app/selectors/sortedReservationsSelector.js
@@ -5,10 +5,10 @@ import { createSelector } from 'reselect';
 
 const reservationsSelector = (state, props) => {
   if (props.filter === 'preliminary') {
-    return filter(state.data.reservations, (reservation) => reservation.id % 5 !== 4);
+    return filter(state.data.reservations, (reservation) => reservation.needManualConfirmation);
   }
   if (props.filter === 'regular') {
-    return filter(state.data.reservations, (reservation) => reservation.id % 5 === 4);
+    return filter(state.data.reservations, (reservation) => !reservation.needManualConfirmation);
   }
   return state.data.reservations;
 };

--- a/app/utils/DataUtils.js
+++ b/app/utils/DataUtils.js
@@ -19,7 +19,6 @@ export default {
   getName,
   getOpeningHours,
   getPeopleCapacityString,
-  getReservationStatus,
   getTranslatedProperty,
 };
 
@@ -132,11 +131,6 @@ function getPeopleCapacityString(capacity) {
     return '';
   }
   return `max ${capacity} hengelle.`;
-}
-
-function getReservationStatus(reservation) {
-  const statuses = ['pending', 'canceled', 'declined', 'accepted', null];
-  return reservation ? statuses[reservation.id % 5] : null;
 }
 
 function getTranslatedProperty(item, property, language = 'fi') {


### PR DESCRIPTION
This PR makes the UI use real reservation states. Previously before API had support for preliminary reservations, the states were created in the UI for demo purposes.

Closes #257.