### PR TITLE
Feature/259 preliminary reservation actions

### DIFF
--- a/app/actions/reservationActions.js
+++ b/app/actions/reservationActions.js
@@ -15,6 +15,7 @@ export default {
   cancelPreliminaryReservation,
   confirmPreliminaryReservation,
   deleteReservation,
+  denyPreliminaryReservation,
   fetchReservations,
   postReservation,
   putReservation,
@@ -53,6 +54,10 @@ function deleteReservation(reservation) {
       headers: getHeadersCreator(),
     },
   };
+}
+
+function denyPreliminaryReservation(reservation) {
+  return putReservation(Object.assign({}, reservation, { state: 'denied' }));
 }
 
 function fetchReservations(params = {}) {

--- a/app/actions/reservationActions.js
+++ b/app/actions/reservationActions.js
@@ -1,4 +1,5 @@
 import { CALL_API } from 'redux-api-middleware';
+import { decamelizeKeys } from 'humps';
 
 import types from 'constants/ActionTypes';
 import { paginatedReservationsSchema } from 'middleware/Schemas';
@@ -11,11 +12,16 @@ import {
 } from 'utils/APIUtils';
 
 export default {
+  confirmPreliminaryReservation,
   deleteReservation,
   fetchReservations,
   postReservation,
   putReservation,
 };
+
+function confirmPreliminaryReservation(reservation) {
+  return putReservation(Object.assign({}, reservation, { state: 'confirmed' }));
+}
 
 function deleteReservation(reservation) {
   return {
@@ -111,7 +117,7 @@ function putReservation(reservation) {
       endpoint: reservation.url,
       method: 'PUT',
       headers: getHeadersCreator(),
-      body: JSON.stringify(reservation),
+      body: JSON.stringify(decamelizeKeys(reservation)),
     },
   };
 }

--- a/app/actions/reservationActions.js
+++ b/app/actions/reservationActions.js
@@ -12,12 +12,17 @@ import {
 } from 'utils/APIUtils';
 
 export default {
+  cancelPreliminaryReservation,
   confirmPreliminaryReservation,
   deleteReservation,
   fetchReservations,
   postReservation,
   putReservation,
 };
+
+function cancelPreliminaryReservation(reservation) {
+  return deleteReservation(reservation);
+}
 
 function confirmPreliminaryReservation(reservation) {
   return putReservation(Object.assign({}, reservation, { state: 'confirmed' }));

--- a/app/components/reservation/ReservationControls.js
+++ b/app/components/reservation/ReservationControls.js
@@ -43,7 +43,7 @@ class ReservationControls extends Component {
           key="deleteButton"
           onClick={props.onDeleteClick}
         >
-          Poista
+          Peru
         </Button>
       ),
       deny: (
@@ -70,6 +70,9 @@ class ReservationControls extends Component {
 
   renderButtons(buttons, isAdmin, reservation) {
     if (!reservation.needManualConfirmation) {
+      if (reservation.state === 'cancelled') {
+        return null;
+      }
       return isAdmin ? [buttons.edit, buttons.delete] : [buttons.edit, buttons.delete];
     }
 

--- a/app/components/reservation/ReservationControls.js
+++ b/app/components/reservation/ReservationControls.js
@@ -30,6 +30,7 @@ class ReservationControls extends Component {
           bsSize="xsmall"
           bsStyle="success"
           key="confirmButton"
+          onClick={props.onConfirmClick}
         >
           Hyväksy
         </Button>
@@ -109,6 +110,7 @@ class ReservationControls extends Component {
 ReservationControls.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
   onCancelClick: PropTypes.func.isRequired,
+  onConfirmClick: PropTypes.func.isRequired,
   onDeleteClick: PropTypes.func.isRequired,
   onEditClick: PropTypes.func.isRequired,
   reservation: PropTypes.object,

--- a/app/components/reservation/ReservationControls.js
+++ b/app/components/reservation/ReservationControls.js
@@ -11,6 +11,7 @@ class ReservationControls extends Component {
           bsSize="xsmall"
           bsStyle="danger"
           key="adminCalcelButton"
+          onClick={props.onCancelClick}
         >
           Peru
         </Button>

--- a/app/components/reservation/ReservationControls.js
+++ b/app/components/reservation/ReservationControls.js
@@ -51,6 +51,7 @@ class ReservationControls extends Component {
           bsSize="xsmall"
           bsStyle="danger"
           key="denyButton"
+          onClick={this.props.onDenyClick}
         >
           Hylkää
         </Button>
@@ -116,6 +117,7 @@ ReservationControls.propTypes = {
   onCancelClick: PropTypes.func.isRequired,
   onConfirmClick: PropTypes.func.isRequired,
   onDeleteClick: PropTypes.func.isRequired,
+  onDenyClick: PropTypes.func.isRequired,
   onEditClick: PropTypes.func.isRequired,
   reservation: PropTypes.object,
 };

--- a/app/components/reservation/ReservationsListItem.js
+++ b/app/components/reservation/ReservationsListItem.js
@@ -82,7 +82,7 @@ class ReservationsListItem extends Component {
   }
 
   renderStateLabel(reservation) {
-    if (!reservation.needManualConfirmation) {
+    if (!reservation.needManualConfirmation && reservation.state !== 'cancelled') {
       return null;
     }
 

--- a/app/components/reservation/ReservationsListItem.js
+++ b/app/components/reservation/ReservationsListItem.js
@@ -20,6 +20,7 @@ class ReservationsListItem extends Component {
     this.handleCancelClick = this.handleCancelClick.bind(this);
     this.handleConfirmClick = this.handleConfirmClick.bind(this);
     this.handleDeleteClick = this.handleDeleteClick.bind(this);
+    this.handleDenyClick = this.handleDenyClick.bind(this);
     this.handleEditClick = this.handleEditClick.bind(this);
   }
 
@@ -55,6 +56,18 @@ class ReservationsListItem extends Component {
 
     selectReservationToDelete(reservation);
     openReservationDeleteModal();
+  }
+
+  handleDenyClick() {
+    const {
+      denyPreliminaryReservation,
+      isAdmin,
+      reservation,
+    } = this.props;
+
+    if (isAdmin && reservation.state === 'requested') {
+      denyPreliminaryReservation(reservation);
+    }
   }
 
   handleEditClick() {
@@ -154,6 +167,7 @@ class ReservationsListItem extends Component {
           onCancelClick={this.handleCancelClick}
           onConfirmClick={this.handleConfirmClick}
           onDeleteClick={this.handleDeleteClick}
+          onDenyClick={this.handleDenyClick}
           onEditClick={this.handleEditClick}
           reservation={reservation}
         />
@@ -165,6 +179,7 @@ class ReservationsListItem extends Component {
 
 ReservationsListItem.propTypes = {
   confirmPreliminaryReservation: PropTypes.func.isRequired,
+  denyPreliminaryReservation: PropTypes.func.isRequired,
   isAdmin: PropTypes.bool.isRequired,
   openReservationCancelModal: PropTypes.func.isRequired,
   openReservationDeleteModal: PropTypes.func.isRequired,

--- a/app/components/reservation/ReservationsListItem.js
+++ b/app/components/reservation/ReservationsListItem.js
@@ -18,6 +18,7 @@ class ReservationsListItem extends Component {
   constructor(props) {
     super(props);
     this.handleCancelClick = this.handleCancelClick.bind(this);
+    this.handleConfirmClick = this.handleConfirmClick.bind(this);
     this.handleDeleteClick = this.handleDeleteClick.bind(this);
     this.handleEditClick = this.handleEditClick.bind(this);
   }
@@ -31,6 +32,18 @@ class ReservationsListItem extends Component {
 
     selectReservationToCancel(reservation);
     openReservationCancelModal();
+  }
+
+  handleConfirmClick() {
+    const {
+      confirmPreliminaryReservation,
+      isAdmin,
+      reservation,
+    } = this.props;
+
+    if (isAdmin && reservation.state === 'requested') {
+      confirmPreliminaryReservation(reservation);
+    }
   }
 
   handleDeleteClick() {
@@ -139,6 +152,7 @@ class ReservationsListItem extends Component {
         <ReservationControls
           isAdmin={isAdmin}
           onCancelClick={this.handleCancelClick}
+          onConfirmClick={this.handleConfirmClick}
           onDeleteClick={this.handleDeleteClick}
           onEditClick={this.handleEditClick}
           reservation={reservation}
@@ -150,6 +164,7 @@ class ReservationsListItem extends Component {
 }
 
 ReservationsListItem.propTypes = {
+  confirmPreliminaryReservation: PropTypes.func.isRequired,
   isAdmin: PropTypes.bool.isRequired,
   openReservationCancelModal: PropTypes.func.isRequired,
   openReservationDeleteModal: PropTypes.func.isRequired,

--- a/app/components/reservation/__tests__/ReservationControls.spec.js
+++ b/app/components/reservation/__tests__/ReservationControls.spec.js
@@ -57,7 +57,7 @@ describe('Component: reservation/ReservationControls', () => {
         const button = buttons.at(1);
 
         it('should be a delete button', () => {
-          expect(button.props().children).to.equal('Poista');
+          expect(button.props().children).to.equal('Peru');
         });
 
         it('clicking the button should call onDeleteClick', () => {
@@ -174,7 +174,7 @@ describe('Component: reservation/ReservationControls', () => {
         const button = buttons.at(1);
 
         it('should be a delete button', () => {
-          expect(button.props().children).to.equal('Poista');
+          expect(button.props().children).to.equal('Peru');
         });
 
         it('clicking the button should call onDeleteClick', () => {

--- a/app/components/reservation/__tests__/ReservationControls.spec.js
+++ b/app/components/reservation/__tests__/ReservationControls.spec.js
@@ -13,6 +13,7 @@ describe('Component: reservation/ReservationControls', () => {
   const onCancelClick = simple.stub();
   const onConfirmClick = simple.stub();
   const onDeleteClick = simple.stub();
+  const onDenyClick = simple.stub();
   const onEditClick = simple.stub();
 
   function getWrapper(reservation, isAdmin = false) {
@@ -21,6 +22,7 @@ describe('Component: reservation/ReservationControls', () => {
       onCancelClick,
       onConfirmClick,
       onDeleteClick,
+      onDenyClick,
       onEditClick,
       reservation: Immutable(reservation),
     };
@@ -84,7 +86,7 @@ describe('Component: reservation/ReservationControls', () => {
           expect(button.props().children).to.equal('Hyväksy');
         });
 
-        it('clicking the button should call onEditClick', () => {
+        it('clicking the button should call onConfirmClick', () => {
           onConfirmClick.reset();
           button.props().onClick();
 
@@ -97,6 +99,13 @@ describe('Component: reservation/ReservationControls', () => {
 
         it('should be a deny button', () => {
           expect(button.props().children).to.equal('Hylkää');
+        });
+
+        it('clicking the button should call onDenyClick', () => {
+          onDenyClick.reset();
+          button.props().onClick();
+
+          expect(onDenyClick.callCount).to.equal(1);
         });
       });
     });

--- a/app/components/reservation/__tests__/ReservationControls.spec.js
+++ b/app/components/reservation/__tests__/ReservationControls.spec.js
@@ -133,6 +133,13 @@ describe('Component: reservation/ReservationControls', () => {
         it('should be a cancel button', () => {
           expect(button.props().children).to.equal('Peru');
         });
+
+        it('clicking the button should call onCancelClick', () => {
+          onCancelClick.reset();
+          button.props().onClick();
+
+          expect(onCancelClick.callCount).to.equal(1);
+        });
       });
     });
   });

--- a/app/components/reservation/__tests__/ReservationControls.spec.js
+++ b/app/components/reservation/__tests__/ReservationControls.spec.js
@@ -11,6 +11,7 @@ import Reservation from 'fixtures/Reservation';
 
 describe('Component: reservation/ReservationControls', () => {
   const onCancelClick = simple.stub();
+  const onConfirmClick = simple.stub();
   const onDeleteClick = simple.stub();
   const onEditClick = simple.stub();
 
@@ -18,6 +19,7 @@ describe('Component: reservation/ReservationControls', () => {
     const props = {
       isAdmin,
       onCancelClick,
+      onConfirmClick,
       onDeleteClick,
       onEditClick,
       reservation: Immutable(reservation),
@@ -80,6 +82,13 @@ describe('Component: reservation/ReservationControls', () => {
 
         it('should be a confirm button', () => {
           expect(button.props().children).to.equal('Hyväksy');
+        });
+
+        it('clicking the button should call onEditClick', () => {
+          onConfirmClick.reset();
+          button.props().onClick();
+
+          expect(onConfirmClick.callCount).to.equal(1);
         });
       });
 

--- a/app/components/reservation/__tests__/ReservationsListItem.spec.js
+++ b/app/components/reservation/__tests__/ReservationsListItem.spec.js
@@ -14,6 +14,7 @@ import Unit from 'fixtures/Unit';
 
 describe('Component: reservation/ReservationsListItem', () => {
   const props = {
+    confirmPreliminaryReservation: simple.stub(),
     isAdmin: false,
     openReservationCancelModal: simple.stub(),
     openReservationDeleteModal: simple.stub(),

--- a/app/components/reservation/__tests__/ReservationsListItem.spec.js
+++ b/app/components/reservation/__tests__/ReservationsListItem.spec.js
@@ -15,6 +15,7 @@ import Unit from 'fixtures/Unit';
 describe('Component: reservation/ReservationsListItem', () => {
   const props = {
     confirmPreliminaryReservation: simple.stub(),
+    denyPreliminaryReservation: simple.stub(),
     isAdmin: false,
     openReservationCancelModal: simple.stub(),
     openReservationDeleteModal: simple.stub(),

--- a/app/containers/ReservationCancelModal.js
+++ b/app/containers/ReservationCancelModal.js
@@ -28,7 +28,7 @@ export class UnconnectedReservationCancelModal extends Component {
     actions.closeReservationCancelModal();
   }
 
-  renderModalContent(cancelAllowed, reservationsToCancel) {
+  renderModalContent(cancelAllowed, reservationsToCancel, reservationInfo) {
     if (cancelAllowed) {
       return (
         <div>
@@ -51,12 +51,7 @@ export class UnconnectedReservationCancelModal extends Component {
           Huomioi kuitenkin, että varaus pitää perua viimeistään <strong>X päivää</strong> ennen
           varauksen alkamista. Käyttämättömät varaukset laskutetaan.
         </p>
-        <h5>Tilasta vastaava virkailja:</h5>
-        <address>
-          Erkki Esimerkki
-          <br />040 123 4567
-          <br /><a href="mailto:erkki@esimerkki.com">erkki@esimerkki.com</a>
-        </address>
+        <p className="reservation-info">{reservationInfo}</p>
       </div>
     );
   }
@@ -77,9 +72,11 @@ export class UnconnectedReservationCancelModal extends Component {
       actions,
       isAdmin,
       reservationsToCancel,
+      resources,
       show,
     } = this.props;
 
+    const resource = reservationsToCancel.length ? resources[reservationsToCancel[0].resource] : {};
     const state = reservationsToCancel.length ? reservationsToCancel[0].state : '';
     const cancelAllowed = isAdmin || state !== 'confirmed';
 
@@ -95,7 +92,7 @@ export class UnconnectedReservationCancelModal extends Component {
         </Modal.Header>
 
         <Modal.Body>
-          {this.renderModalContent(cancelAllowed, reservationsToCancel)}
+          {this.renderModalContent(cancelAllowed, reservationsToCancel, resource.reservationInfo)}
         </Modal.Body>
 
         <Modal.Footer>

--- a/app/containers/ReservationDeleteModal.js
+++ b/app/containers/ReservationDeleteModal.js
@@ -54,11 +54,11 @@ export class UnconnectedReservationDeleteModal extends Component {
         show={show}
       >
         <Modal.Header closeButton>
-          <Modal.Title>Poistamisen vahvistus</Modal.Title>
+          <Modal.Title>Perumisen vahvistus</Modal.Title>
         </Modal.Header>
 
         <Modal.Body>
-          <p><strong>Oletko varma että haluat poistaa seuraavat varaukset?</strong></p>
+          <p><strong>Oletko varma että haluat perua seuraavat varaukset?</strong></p>
           <ul>
             {map(reservationsToDelete, this.renderReservation)}
           </ul>
@@ -76,7 +76,7 @@ export class UnconnectedReservationDeleteModal extends Component {
             disabled={isDeletingReservations}
             onClick={this.handleDelete}
           >
-            {isDeletingReservations ? 'Poistetaan...' : 'Poista'}
+            {isDeletingReservations ? 'Poistetaan...' : 'Peru'}
           </Button>
         </Modal.Footer>
       </Modal>

--- a/app/containers/ReservationsList.js
+++ b/app/containers/ReservationsList.js
@@ -12,6 +12,9 @@ import {
   selectReservationToDelete,
   selectReservationToEdit,
 } from 'actions/uiActions';
+import {
+  confirmPreliminaryReservation,
+} from 'actions/reservationActions';
 import ReservationCancelModal from 'containers/ReservationCancelModal';
 import ReservationDeleteModal from 'containers/ReservationDeleteModal';
 import ReservationsListItem from 'components/reservation/ReservationsListItem';
@@ -35,6 +38,7 @@ export class UnconnectedReservationsList extends Component {
 
     return (
       <ReservationsListItem
+        confirmPreliminaryReservation={actions.confirmPreliminaryReservation}
         isAdmin={isAdmin}
         key={reservation.url}
         reservation={reservation}
@@ -88,6 +92,7 @@ UnconnectedReservationsList.propTypes = {
 
 function mapDispatchToProps(dispatch) {
   const actionCreators = {
+    confirmPreliminaryReservation,
     openReservationCancelModal,
     openReservationDeleteModal,
     updatePath,

--- a/app/containers/ReservationsList.js
+++ b/app/containers/ReservationsList.js
@@ -14,6 +14,7 @@ import {
 } from 'actions/uiActions';
 import {
   confirmPreliminaryReservation,
+  denyPreliminaryReservation,
 } from 'actions/reservationActions';
 import ReservationCancelModal from 'containers/ReservationCancelModal';
 import ReservationDeleteModal from 'containers/ReservationDeleteModal';
@@ -39,6 +40,7 @@ export class UnconnectedReservationsList extends Component {
     return (
       <ReservationsListItem
         confirmPreliminaryReservation={actions.confirmPreliminaryReservation}
+        denyPreliminaryReservation={actions.denyPreliminaryReservation}
         isAdmin={isAdmin}
         key={reservation.url}
         reservation={reservation}
@@ -93,6 +95,7 @@ UnconnectedReservationsList.propTypes = {
 function mapDispatchToProps(dispatch) {
   const actionCreators = {
     confirmPreliminaryReservation,
+    denyPreliminaryReservation,
     openReservationCancelModal,
     openReservationDeleteModal,
     updatePath,

--- a/app/containers/__tests__/ReservationCancelModal.spec.js
+++ b/app/containers/__tests__/ReservationCancelModal.spec.js
@@ -12,7 +12,8 @@ import Reservation from 'fixtures/Reservation';
 import Resource from 'fixtures/Resource';
 
 describe('Container: ReservationCancelModal', () => {
-  const resource = Resource.build();
+  const reservationInfo = 'Some reservation info.';
+  const resource = Resource.build({ reservationInfo });
   const props = {
     actions: {
       cancelPreliminaryReservation: simple.stub(),
@@ -298,10 +299,10 @@ describe('Container: ReservationCancelModal', () => {
           expect(modalBodyTrees.length).to.equal(1);
         });
 
-        it('should render contact information', () => {
-          const addressTree = modalBodyTrees[0].subTree('address');
+        it('should render resource reservationInfo', () => {
+          const modalText = modalBodyTrees[0].subTree('.reservation-info').text();
 
-          expect(addressTree).to.be.ok;
+          expect(modalText).to.contain(reservationInfo);
         });
       });
 

--- a/app/containers/__tests__/ReservationCancelModal.spec.js
+++ b/app/containers/__tests__/ReservationCancelModal.spec.js
@@ -15,8 +15,10 @@ describe('Container: ReservationCancelModal', () => {
   const resource = Resource.build();
   const props = {
     actions: {
+      cancelPreliminaryReservation: simple.stub(),
       closeReservationCancelModal: simple.stub(),
     },
+    isAdmin: false,
     show: true,
     reservationsToCancel: Immutable([
       Reservation.build({ resource: resource.id }),
@@ -44,7 +46,113 @@ describe('Container: ReservationCancelModal', () => {
   }
 
   describe('render', () => {
-    describe('when reservation state is anything but "confirmed"', () => {
+    describe('when isAdmin is true', () => {
+      const isAdmin = true;
+      const extraProps = Object.assign(getExtraProps('requested'), { isAdmin });
+      const tree = getTree(extraProps);
+      const instance = tree.getMountedInstance();
+
+      it('should render a Modal component', () => {
+        const modalTrees = tree.everySubTree('Modal');
+
+        expect(modalTrees.length).to.equal(1);
+      });
+
+      describe('Modal header', () => {
+        const modalHeaderTrees = tree.everySubTree('ModalHeader');
+
+        it('should render a ModalHeader component', () => {
+          expect(modalHeaderTrees.length).to.equal(1);
+        });
+
+        it('should contain a close button', () => {
+          expect(modalHeaderTrees[0].props.closeButton).to.equal(true);
+        });
+
+        it('should render a ModalTitle component', () => {
+          const modalTitleTrees = tree.everySubTree('ModalTitle');
+
+          expect(modalTitleTrees.length).to.equal(1);
+        });
+
+        it('the ModalTitle should display text "Varauksen perumisen vahvistus"', () => {
+          const modalTitleTree = tree.subTree('ModalTitle');
+
+          expect(modalTitleTree.props.children).to.equal('Varauksen perumisen vahvistus');
+        });
+      });
+
+      describe('Modal body', () => {
+        const modalBodyTrees = tree.everySubTree('ModalBody');
+
+        it('should render a ModalBody component', () => {
+          expect(modalBodyTrees.length).to.equal(1);
+        });
+
+        it('should render a list for selected reservations', () => {
+          const listTrees = modalBodyTrees[0].everySubTree('ul');
+
+          expect(listTrees.length).to.equal(1);
+        });
+
+        it('should render a list element for each selected reservation', () => {
+          const listElementTrees = modalBodyTrees[0].everySubTree('li');
+
+          expect(listElementTrees.length).to.equal(props.reservationsToCancel.length);
+        });
+
+        it('should display a TimeRange for each selected reservation', () => {
+          const timeRangeTrees = modalBodyTrees[0].everySubTree('TimeRange');
+
+          expect(timeRangeTrees.length).to.equal(props.reservationsToCancel.length);
+        });
+      });
+
+      describe('Modal footer', () => {
+        const modalFooterTrees = tree.everySubTree('ModalFooter');
+
+        it('should render a ModalFooter component', () => {
+          expect(modalFooterTrees.length).to.equal(1);
+        });
+
+        describe('Footer buttons', () => {
+          const buttonTrees = modalFooterTrees[0].everySubTree('Button');
+
+          it('should render two Buttons', () => {
+            expect(buttonTrees.length).to.equal(2);
+          });
+
+          describe('Cancel button', () => {
+            const buttonTree = buttonTrees[0];
+
+            it('the first button should read "Älä peruuta varausta"', () => {
+              expect(buttonTree.props.children).to.equal('Älä peruuta varausta');
+            });
+
+            it('clicking it should call closeReservationCancelModal', () => {
+              props.actions.closeReservationCancelModal.reset();
+              buttonTree.props.onClick();
+
+              expect(props.actions.closeReservationCancelModal.callCount).to.equal(1);
+            });
+          });
+
+          describe('Confirm button', () => {
+            const buttonTree = buttonTrees[1];
+
+            it('the second button should read "Peruuta varaus"', () => {
+              expect(buttonTree.props.children).to.equal('Peruuta varaus');
+            });
+
+            it('should have handleCancel as its onClick prop', () => {
+              expect(buttonTree.props.onClick).to.equal(instance.handleCancel);
+            });
+          });
+        });
+      });
+    });
+
+    describe('when isAdmin is false and reservation state is anything but "confirmed"', () => {
       const extraProps = getExtraProps('requested');
       const tree = getTree(extraProps);
       const instance = tree.getMountedInstance();
@@ -149,7 +257,7 @@ describe('Container: ReservationCancelModal', () => {
       });
     });
 
-    describe('when reservation state is "confirmed"', () => {
+    describe('when isAdmin is false and reservation state is "confirmed"', () => {
       const extraProps = getExtraProps('confirmed');
       const tree = getTree(extraProps);
 
@@ -241,6 +349,19 @@ describe('Container: ReservationCancelModal', () => {
 
     it('should call closeReservationCancelModal', () => {
       expect(props.actions.closeReservationCancelModal.callCount).to.equal(1);
+    });
+
+    it('should call cancelPreliminaryReservation for each selected reservation', () => {
+      expect(props.actions.cancelPreliminaryReservation.callCount).to.equal(
+        props.reservationsToCancel.length
+      );
+    });
+
+    it('should call cancelPreliminaryReservation with correct arguments', () => {
+      const actualArgs = props.actions.cancelPreliminaryReservation.lastCall.args;
+      const expected = props.reservationsToCancel[1];
+
+      expect(actualArgs[0]).to.deep.equal(expected);
     });
   });
 });

--- a/app/containers/__tests__/ReservationDeleteModal.spec.js
+++ b/app/containers/__tests__/ReservationDeleteModal.spec.js
@@ -56,10 +56,10 @@ describe('Container: ReservationDeleteModal', () => {
         expect(modalTitleTrees.length).to.equal(1);
       });
 
-      it('the ModalTitle should display text "Poistamisen vahvistus"', () => {
+      it('the ModalTitle should display text "Perumisen vahvistus"', () => {
         const modalTitleTree = tree.subTree('ModalTitle');
 
-        expect(modalTitleTree.props.children).to.equal('Poistamisen vahvistus');
+        expect(modalTitleTree.props.children).to.equal('Perumisen vahvistus');
       });
     });
 
@@ -121,8 +121,8 @@ describe('Container: ReservationDeleteModal', () => {
         describe('Confirm button', () => {
           const buttonTree = buttonTrees[1];
 
-          it('the second button should read "Poista"', () => {
-            expect(buttonTree.props.children).to.equal('Poista');
+          it('the second button should read "Peru"', () => {
+            expect(buttonTree.props.children).to.equal('Peru');
           });
 
           it('should have handleDelete as its onClick prop', () => {

--- a/app/containers/__tests__/ReservationsList.spec.js
+++ b/app/containers/__tests__/ReservationsList.spec.js
@@ -16,6 +16,7 @@ function getProps(props) {
   const defaults = {
     actions: {
       confirmPreliminaryReservation: simple.stub(),
+      denyPreliminaryReservation: simple.stub(),
       openReservationCancelModal: simple.stub(),
       openReservationDeleteModal: simple.stub(),
       updatePath: simple.stub(),
@@ -78,6 +79,7 @@ describe('Container: ReservationsList', () => {
           const actualProps = reservationTree.props;
 
           expect(actualProps.confirmPreliminaryReservation).to.deep.equal(props.actions.confirmPreliminaryReservation);
+          expect(actualProps.denyPreliminaryReservation).to.deep.equal(props.actions.denyPreliminaryReservation);
           expect(actualProps.isAdmin).to.equal(props.isAdmin);
           expect(actualProps.reservation).to.deep.equal(props.reservations[index]);
           expect(actualProps.openReservationCancelModal).to.deep.equal(props.actions.openReservationCancelModal);

--- a/app/containers/__tests__/ReservationsList.spec.js
+++ b/app/containers/__tests__/ReservationsList.spec.js
@@ -15,6 +15,7 @@ import Unit from 'fixtures/Unit';
 function getProps(props) {
   const defaults = {
     actions: {
+      confirmPreliminaryReservation: simple.stub(),
       openReservationCancelModal: simple.stub(),
       openReservationDeleteModal: simple.stub(),
       updatePath: simple.stub(),
@@ -76,6 +77,7 @@ describe('Container: ReservationsList', () => {
         reservationsListItemTrees.forEach((reservationTree, index) => {
           const actualProps = reservationTree.props;
 
+          expect(actualProps.confirmPreliminaryReservation).to.deep.equal(props.actions.confirmPreliminaryReservation);
           expect(actualProps.isAdmin).to.equal(props.isAdmin);
           expect(actualProps.reservation).to.deep.equal(props.reservations[index]);
           expect(actualProps.openReservationCancelModal).to.deep.equal(props.actions.openReservationCancelModal);

--- a/app/reducers/notificationsReducer.js
+++ b/app/reducers/notificationsReducer.js
@@ -73,7 +73,7 @@ function notificationsReducer(state = initialState, action) {
 
   case types.API.RESERVATION_PUT_SUCCESS:
     notification = {
-      message: 'Varauksen muuttaminen onnistui.',
+      message: 'Varaus päivitetty.',
       type: 'success',
     };
     return addNotification(state, notification);

--- a/app/reducers/notificationsReducer.js
+++ b/app/reducers/notificationsReducer.js
@@ -59,7 +59,7 @@ function notificationsReducer(state = initialState, action) {
 
   case types.API.RESERVATION_DELETE_SUCCESS:
     notification = {
-      message: 'Varauksen poistaminen onnistui.',
+      message: 'Varauksen peruminen onnistui.',
       type: 'success',
     };
     return addNotification(state, notification);

--- a/app/selectors/containers/__tests__/reservationCancelModalSelector.spec.js
+++ b/app/selectors/containers/__tests__/reservationCancelModalSelector.spec.js
@@ -8,6 +8,10 @@ describe('Selector: reservationCancelModalSelector', () => {
   const props = getDefaultRouterProps();
   const selected = reservationCancelModalSelector(state, props);
 
+  it('should return isAdmin', () => {
+    expect(selected.isAdmin).to.exist;
+  });
+
   it('should return show', () => {
     expect(selected.show).to.exist;
   });

--- a/app/selectors/containers/reservationCancelModalSelector.js
+++ b/app/selectors/containers/reservationCancelModalSelector.js
@@ -1,21 +1,25 @@
 import { createSelector } from 'reselect';
 
 import ModalTypes from 'constants/ModalTypes';
+import isAdminSelector from 'selectors/isAdminSelector';
 import modalIsOpenSelectorFactory from 'selectors/factories/modalIsOpenSelectorFactory';
 
 const toCancelSelector = (state) => state.ui.reservation.toCancel;
 const resourcesSelector = (state) => state.data.resources;
 
 const reservationCancelModalSelector = createSelector(
+  isAdminSelector,
   modalIsOpenSelectorFactory(ModalTypes.CANCEL_RESERVATION),
   resourcesSelector,
   toCancelSelector,
   (
+    isAdmin,
     cancelReservationModalIsOpen,
     resources,
     reservationsToCancel
   ) => {
     return {
+      isAdmin,
       reservationsToCancel,
       resources,
       show: cancelReservationModalIsOpen,


### PR DESCRIPTION
This PR:
- adds the following reservation actions for admins:
  - deny
  - confirm
  - cancel
- adds the following reservation actions for regular users:
  - cancel
- makes user reservations list and actions work with the new reservation delete / cancel API changes
- uses real reservationInfo text in reservation cancel modal text

Closes #259.