### PR TITLE
Switch reservations lists order in admin view

### DIFF
--- a/app/containers/UserReservationsPage.js
+++ b/app/containers/UserReservationsPage.js
@@ -32,15 +32,15 @@ export class UnconnectedUserReservationsPage extends Component {
             )}
             { isAdmin && (
               <div>
-                <h1>Tavalliset varaukset</h1>
-                <ReservationsList
-                  emptyMessage="Ei tavallisia varauksia näytettäväksi."
-                  filter="regular"
-                />
                 <h1>Alustavat varaukset</h1>
                 <ReservationsList
                   emptyMessage="Ei alustavia varauksia näytettäväksi."
                   filter="preliminary"
+                  />
+                <h1>Tavalliset varaukset</h1>
+                <ReservationsList
+                  emptyMessage="Ei tavallisia varauksia näytettäväksi."
+                  filter="regular"
                 />
               </div>
             )}

--- a/app/containers/__tests__/UserReservationsPage.spec.js
+++ b/app/containers/__tests__/UserReservationsPage.spec.js
@@ -52,12 +52,12 @@ describe('Container: UserReservationsPage', () => {
           expect(headers.length).to.equal(2);
         });
 
-        it('the first header should display "Tavalliset varaukset"', () => {
-          expect(headers.at(0).text()).to.equal('Tavalliset varaukset');
+        it('the first header should display "Alustavat varaukset"', () => {
+          expect(headers.at(0).text()).to.equal('Alustavat varaukset');
         });
 
-        it('the first header should display "Alustavat varaukset"', () => {
-          expect(headers.at(1).text()).to.equal('Alustavat varaukset');
+        it('the second header should display "Tavalliset varaukset"', () => {
+          expect(headers.at(1).text()).to.equal('Tavalliset varaukset');
         });
       });
 
@@ -68,12 +68,12 @@ describe('Container: UserReservationsPage', () => {
           expect(lists.length).to.equal(2);
         });
 
-        it('the first list should only contain regular reservations', () => {
-          expect(lists.at(0).props().filter).to.equal('regular');
+        it('the first list should only contain preliminary reservations', () => {
+          expect(lists.at(0).props().filter).to.equal('preliminary');
         });
 
-        it('the second list should only contain preliminary reservations', () => {
-          expect(lists.at(1).props().filter).to.equal('preliminary');
+        it('the second list should only contain regular reservations', () => {
+          expect(lists.at(1).props().filter).to.equal('regular');
         });
       });
     });


### PR DESCRIPTION
Moves preliminary reservations list before regular reservations list.
Closes #264.