### PR TITLE
Make reservation calendar responsive

### DIFF
--- a/app/components/reservation/TimeSlots.js
+++ b/app/components/reservation/TimeSlots.js
@@ -63,6 +63,7 @@ class TimeSlots extends Component {
           <Table
             className="time-slots lined"
             hover
+            responsive
           >
             <thead>
               <tr>


### PR DESCRIPTION
This is needed for admins who have more information on the
calendar.
It also makes the reservation form not expand more than the screen width.
Closes #272.