### PR TITLE
Render all reservation form fields by default

### DIFF
--- a/app/actions/reservationActions.js
+++ b/app/actions/reservationActions.js
@@ -1,5 +1,6 @@
-import { CALL_API } from 'redux-api-middleware';
+import pick from 'lodash/object/pick';
 import { decamelizeKeys } from 'humps';
+import { CALL_API } from 'redux-api-middleware';
 
 import types from 'constants/ActionTypes';
 import { paginatedReservationsSchema } from 'middleware/Schemas';
@@ -80,6 +81,11 @@ function fetchReservations(params = {}) {
   };
 }
 
+function parseReservationData(reservation) {
+  const parsed = pick(reservation, (value) => value);
+  return JSON.stringify(decamelizeKeys(parsed));
+}
+
 function postReservation(reservation) {
   const url = buildAPIUrl('reservation');
 
@@ -102,7 +108,7 @@ function postReservation(reservation) {
       endpoint: url,
       method: 'POST',
       headers: getHeadersCreator(),
-      body: JSON.stringify(reservation),
+      body: parseReservationData(reservation),
     },
   };
 }
@@ -127,7 +133,7 @@ function putReservation(reservation) {
       endpoint: reservation.url,
       method: 'PUT',
       headers: getHeadersCreator(),
-      body: JSON.stringify(decamelizeKeys(reservation)),
+      body: parseReservationData(reservation),
     },
   };
 }

--- a/app/components/reservation/ConfirmReservationModal.js
+++ b/app/components/reservation/ConfirmReservationModal.js
@@ -3,6 +3,7 @@ import React, { Component, PropTypes } from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 
 import TimeRange from 'components/common/TimeRange';
+import { RESERVATION_FORM_FIELDS } from 'constants/AppConstants';
 import ReservationForm from 'containers/ReservationForm';
 
 class ConfirmReservationModal extends Component {
@@ -23,7 +24,10 @@ class ConfirmReservationModal extends Component {
   getFormFields() {
     const { resource } = this.props;
     const isAdmin = resource.userPermissions.isAdmin;
-    const formFields = [...resource.requiredReservationExtraFields];
+    const formFields = [];
+    if (resource.needManualConfirmation) {
+      formFields.push(...RESERVATION_FORM_FIELDS);
+    }
 
     if (isAdmin) {
       formFields.push('comments');

--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -13,6 +13,21 @@ export default {
     'Accept-Language': 'fi',
     'Content-Type': 'application/json',
   },
+  RESERVATION_FORM_FIELDS: [
+    'reserver_name',
+    'reserver_email',
+    'reserver_phone_number',
+    'event_description',
+    'reserver_address_street',
+    'reserver_address_zip',
+    'reserver_address_city',
+    'company',
+    'business_id',
+    'billing_address_street',
+    'billing_address_zip',
+    'billing_address_city',
+    'number_of_participants',
+  ],
   RESERVATION_STATE_LABELS: {
     cancelled: {
       labelBsStyle: 'default',

--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -15,7 +15,7 @@ export default {
   },
   RESERVATION_FORM_FIELDS: [
     'reserver_name',
-    'reserver_email',
+    'reserver_email_address',
     'reserver_phone_number',
     'event_description',
     'reserver_address_street',

--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -8,8 +8,8 @@ import { reduxForm } from 'redux-form';
 import isEmail from 'validator/lib/isEmail';
 
 const validators = {
-  reserver_email: ({ reserver_email }) => {
-    if (reserver_email && !isEmail(reserver_email)) {
+  reserver_email_address: ({ reserver_email_address }) => {
+    if (reserver_email_address && !isEmail(reserver_email_address)) {
       return 'Syötä kunnollinen sähköpostiosoite';
     }
   },
@@ -26,7 +26,7 @@ const maxLengths = {
   reserver_address_city: 100,
   reserver_address_street: 100,
   reserver_address_zip: 30,
-  reserver_email: 100,
+  reserver_email_address: 100,
   reserver_name: 100,
   reserver_phone_number: 30,
 };
@@ -89,7 +89,7 @@ export class UnconnectedReservationForm extends Component {
       <div>
         <form className="reservation-form form-horizontal">
           {this.renderField('text', 'Nimi', fields.reserver_name)}
-          {this.renderField('email', 'Sähköposti', fields.reserver_email)}
+          {this.renderField('email', 'Sähköposti', fields.reserver_email_address)}
           {this.renderField('text', 'Puhelin', fields.reserver_phone_number)}
           {this.renderField('textarea', 'Tilaisuuden kuvaus', fields.event_description, { rows: 5 })}
           { fields.reserver_address_street && (

--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -15,6 +15,22 @@ const validators = {
   },
 };
 
+const maxLengths = {
+  billing_address_city: 100,
+  billing_address_street: 100,
+  billing_address_zip: 30,
+  business_id: 9,
+  company: 100,
+  event_description: 100,
+  number_of_participants: 100,
+  reserver_address_city: 100,
+  reserver_address_street: 100,
+  reserver_address_zip: 30,
+  reserver_email: 100,
+  reserver_name: 100,
+  reserver_phone_number: 30,
+};
+
 export function validate(values, { fields, requiredFields }) {
   const errors = {};
   fields.forEach((field) => {
@@ -23,6 +39,11 @@ export function validate(values, { fields, requiredFields }) {
       const error = validator(values);
       if (error) {
         errors[field] = error;
+      }
+    }
+    if (maxLengths[field]) {
+      if (values[field] && values[field].length > maxLengths[field]) {
+        errors[field] = `Kentän maksimipituus on ${maxLengths[field]} merkkiä`;
       }
     }
     if (includes(requiredFields, field)) {

--- a/app/containers/__tests__/ReservationForm.spec.js
+++ b/app/containers/__tests__/ReservationForm.spec.js
@@ -44,22 +44,22 @@ describe('Container: ReservationForm', () => {
       });
     });
 
-    describe('reserver_email', () => {
+    describe('reserver_email_address', () => {
       const props = {
-        fields: ['reserver_email'],
+        fields: ['reserver_email_address'],
         requiredFields: [],
       };
 
-      it('should return an error if reserver_email is invalid', () => {
-        const values = { reserver_email: 'luke@' };
+      it('should return an error if reserver_email_address is invalid', () => {
+        const values = { reserver_email_address: 'luke@' };
         const errors = validate(values, props);
-        expect(errors.reserver_email).to.exist;
+        expect(errors.reserver_email_address).to.exist;
       });
 
-      it('should not return an error if reserver_email is valid', () => {
-        const values = { reserver_email: 'luke@skywalker.com' };
+      it('should not return an error if reserver_email_address is valid', () => {
+        const values = { reserver_email_address: 'luke@skywalker.com' };
         const errors = validate(values, props);
-        expect(errors.reserver_email).to.not.exist;
+        expect(errors.reserver_email_address).to.not.exist;
       });
     });
   });


### PR DESCRIPTION
This PR:
- Renders all reservation form fields by default for preliminary reservations.
- Only sends data to backend from fields that have non-empty strings.
- Adds some max-length validators to the form fields.

Closes #275.