### PR TITLE
Update webpack to version 1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "skin-deep": "^0.13.0",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
-    "webpack": "^1.12.9",
+    "webpack": "^1.13.0",
     "webpack-dev-middleware": "^1.4.0",
     "webpack-hot-middleware": "^2.5.0",
     "webpack-merge": "^0.3.2"


### PR DESCRIPTION
Gets rid of unnecessary depracation warnings in latest Chrome
dev console.