### PR TITLE
Show reservations admin can approve in list

### DIFF
--- a/app/containers/UserReservationsPage.js
+++ b/app/containers/UserReservationsPage.js
@@ -20,12 +20,20 @@ export class UnconnectedUserReservationsPage extends Component {
     this.props.actions.fetchReservations({ isOwn: true });
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (!this.props.resourcesLoaded && nextProps.resourcesLoaded) {
+      if (nextProps.isAdmin) {
+        this.props.actions.fetchReservations({ canApprove: true });
+      }
+    }
+  }
+
   render() {
-    const { isAdmin, isFetchingResources } = this.props;
+    const { isAdmin, resourcesLoaded } = this.props;
 
     return (
       <DocumentTitle title="Omat varaukset - Varaamo">
-        <Loader loaded={!isFetchingResources}>
+        <Loader loaded={resourcesLoaded}>
           <div>
             { !isAdmin && (
               <div>
@@ -60,7 +68,7 @@ export class UnconnectedUserReservationsPage extends Component {
 UnconnectedUserReservationsPage.propTypes = {
   actions: PropTypes.object.isRequired,
   isAdmin: PropTypes.bool.isRequired,
-  isFetchingResources: PropTypes.bool.isRequired,
+  resourcesLoaded: PropTypes.bool.isRequired,
 };
 
 function mapDispatchToProps(dispatch) {

--- a/app/selectors/containers/__tests__/userReservationsPageSelector.spec.js
+++ b/app/selectors/containers/__tests__/userReservationsPageSelector.spec.js
@@ -12,7 +12,7 @@ describe('Selector: userReservationsPageSelector', () => {
     expect(selected.isAdmin).to.exist;
   });
 
-  it('should return isFetchingResources', () => {
-    expect(selected.isFetchingResources).to.exist;
+  it('should return resourcesLoaded', () => {
+    expect(selected.resourcesLoaded).to.exist;
   });
 });

--- a/app/selectors/containers/userReservationsPageSelector.js
+++ b/app/selectors/containers/userReservationsPageSelector.js
@@ -1,19 +1,20 @@
+import isEmpty from 'lodash/lang/isEmpty';
 import { createSelector } from 'reselect';
 
-import ActionTypes from 'constants/ActionTypes';
 import isAdminSelector from 'selectors/isAdminSelector';
-import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
+
+const resourcesSelector = (state) => state.data.resources;
 
 const userReservationsPageSelector = createSelector(
   isAdminSelector,
-  requestIsActiveSelectorFactory(ActionTypes.API.RESOURCES_GET_REQUEST),
+  resourcesSelector,
   (
     isAdmin,
-    isFetchingResources
+    resources
   ) => {
     return {
       isAdmin,
-      isFetchingResources,
+      resourcesLoaded: !isEmpty(resources),
     };
   }
 );


### PR DESCRIPTION
This PR:
- Shows all reservations in user reservation page an admin can approve.
- Makes sure the page is only rendered once it's known whether user is an admin or not.

Closes #274.