### PR TITLE
Make logged actions collapsed by default

### DIFF
--- a/app/store/configureStore.js
+++ b/app/store/configureStore.js
@@ -9,7 +9,10 @@ const storeEnhancers = [applyMiddleware(apiMiddleware)];
 
 if (isDevelopment) {
   const createLogger = require('redux-logger');
-  const loggerMiddleware = createLogger();
+  const loggerMiddleware = createLogger({
+    collapsed: true,
+    duration: true,
+  });
   storeEnhancers.push(applyMiddleware(loggerMiddleware));
   if (__DEVTOOLS__) {
     const { devTools, persistState } = require('redux-devtools');


### PR DESCRIPTION
This makes it lot easier to follow in the console what actions are fired.