### PR TITLE
Always show can approve reservations for admin

### DIFF
--- a/app/containers/UserReservationsPage.js
+++ b/app/containers/UserReservationsPage.js
@@ -15,16 +15,20 @@ import userReservationsPageSelector from 'selectors/containers/userReservationsP
 
 export class UnconnectedUserReservationsPage extends Component {
   componentDidMount() {
+    this.adminReservationsLoaded = false;
+    if (this.props.isAdmin) {
+      this.props.actions.fetchReservations({ canApprove: true });
+      this.adminReservationsLoaded = true;
+    }
     this.props.actions.fetchResources();
     this.props.actions.fetchUnits();
     this.props.actions.fetchReservations({ isOwn: true });
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!this.props.resourcesLoaded && nextProps.resourcesLoaded) {
-      if (nextProps.isAdmin) {
-        this.props.actions.fetchReservations({ canApprove: true });
-      }
+    if (!this.adminReservationsLoaded && nextProps.isAdmin) {
+      this.props.actions.fetchReservations({ canApprove: true });
+      this.adminReservationsLoaded = true;
     }
   }
 

--- a/app/selectors/containers/userReservationsPageSelector.js
+++ b/app/selectors/containers/userReservationsPageSelector.js
@@ -1,20 +1,19 @@
-import isEmpty from 'lodash/lang/isEmpty';
 import { createSelector } from 'reselect';
 
 import isAdminSelector from 'selectors/isAdminSelector';
 
-const resourcesSelector = (state) => state.data.resources;
+const resourcesLoadedSelector = (state) => !state.api.shouldFetch.resources;
 
 const userReservationsPageSelector = createSelector(
   isAdminSelector,
-  resourcesSelector,
+  resourcesLoadedSelector,
   (
     isAdmin,
-    resources
+    resourcesLoaded
   ) => {
     return {
       isAdmin,
-      resourcesLoaded: !isEmpty(resources),
+      resourcesLoaded,
     };
   }
 );


### PR DESCRIPTION
Previous implementation did not consider cases where resources were
already loaded and it was known on mount whether user is an admin or not.
Refs #274.