### PR TITLE
Feature/278 comment editing to reservation info modal

### DIFF
--- a/app/containers/ReservationInfoModal.js
+++ b/app/containers/ReservationInfoModal.js
@@ -72,7 +72,7 @@ export class UnconnectedReservationInfoModal extends Component {
         show={show}
       >
         <Modal.Header closeButton>
-          <Modal.Title>Varaukset tiedot</Modal.Title>
+          <Modal.Title>Varauksen tiedot</Modal.Title>
         </Modal.Header>
 
         <Modal.Body>

--- a/app/containers/ReservationInfoModal.js
+++ b/app/containers/ReservationInfoModal.js
@@ -6,12 +6,29 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import { closeReservationInfoModal } from 'actions/uiActions';
+import { putReservation } from 'actions/reservationActions';
 import TimeRange from 'components/common/TimeRange';
 import reservationInfoModalSelector from 'selectors/containers/reservationInfoModalSelector';
 import { getName } from 'utils/DataUtils';
 import { renderReservationStateLabel } from 'utils/renderUtils';
 
 export class UnconnectedReservationInfoModal extends Component {
+  constructor(props) {
+    super(props);
+    this.handleSave = this.handleSave.bind(this);
+  }
+
+  handleSave() {
+    const { actions, reservationsToShow } = this.props;
+    const reservation = reservationsToShow.length ? reservationsToShow[0] : undefined;
+    if (!reservation) {
+      return;
+    }
+    const comments = this.refs.commentsInput.getValue();
+    actions.putReservation(Object.assign({}, reservation, { comments }));
+    actions.closeReservationInfoModal();
+  }
+
   renderModalContent(reservation, resource) {
     if (!reservation) {
       return null;
@@ -57,6 +74,7 @@ export class UnconnectedReservationInfoModal extends Component {
   render() {
     const {
       actions,
+      isEditingReservations,
       reservationsToShow,
       resources,
       show,
@@ -86,6 +104,14 @@ export class UnconnectedReservationInfoModal extends Component {
           >
             Takaisin
           </Button>
+          <Button
+            bsStyle="primary"
+            disabled={isEditingReservations}
+            onClick={this.handleSave}
+            type="submit"
+          >
+            {isEditingReservations ? 'Tallennetaan...' : 'Tallenna'}
+          </Button>
         </Modal.Footer>
       </Modal>
     );
@@ -94,6 +120,7 @@ export class UnconnectedReservationInfoModal extends Component {
 
 UnconnectedReservationInfoModal.propTypes = {
   actions: PropTypes.object.isRequired,
+  isEditingReservations: PropTypes.bool.isRequired,
   reservationsToShow: PropTypes.array.isRequired,
   resources: PropTypes.object.isRequired,
   show: PropTypes.bool.isRequired,
@@ -102,6 +129,7 @@ UnconnectedReservationInfoModal.propTypes = {
 function mapDispatchToProps(dispatch) {
   const actionCreators = {
     closeReservationInfoModal,
+    putReservation,
   };
 
   return { actions: bindActionCreators(actionCreators, dispatch) };

--- a/app/containers/ReservationInfoModal.js
+++ b/app/containers/ReservationInfoModal.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import Button from 'react-bootstrap/lib/Button';
+import Input from 'react-bootstrap/lib/Input';
 import Modal from 'react-bootstrap/lib/Modal';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -38,8 +39,17 @@ export class UnconnectedReservationInfoModal extends Component {
           <dt>Tila:</dt><dd>{getName(resource)}</dd>
           <dt>Osallistujamäärä:</dt><dd>{reservation.numberOfParticipants}</dd>
           <dt>Tilaisuuden kuvaus:</dt><dd>{reservation.eventDescription}</dd>
-          <dt>Kommentit:</dt><dd>{reservation.comments}</dd>
         </dl>
+        <form>
+          <Input
+            defaultValue={reservation.comments}
+            label="Kommentit:"
+            placeholder="Varauksen mahdolliset lisätiedot"
+            ref="commentsInput"
+            rows={5}
+            type="textarea"
+          />
+        </form>
       </div>
     );
   }

--- a/app/containers/__tests__/ReservationInfoModal.spec.js
+++ b/app/containers/__tests__/ReservationInfoModal.spec.js
@@ -1,0 +1,197 @@
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import Button from 'react-bootstrap/lib/Button';
+import Input from 'react-bootstrap/lib/Input';
+import Modal from 'react-bootstrap/lib/Modal';
+import simple from 'simple-mock';
+
+import Immutable from 'seamless-immutable';
+
+import {
+  UnconnectedReservationInfoModal as ReservationInfoModal,
+} from 'containers/ReservationInfoModal';
+import Reservation from 'fixtures/Reservation';
+import Resource from 'fixtures/Resource';
+
+describe('Container: ReservationInfoModal', () => {
+  const resource = Resource.build();
+  const reservation = Reservation.build({
+    billingAddressCity: 'New York',
+    billingAddressStreet: 'Billing Street 11',
+    billingAddressZip: '99999',
+    businessId: '1234567',
+    comments: 'Just some comments.',
+    company: 'Rebellion',
+    eventDescription: 'Jedi mind tricks',
+    numberOfParticipants: 12,
+    reserverAddressCity: 'Mos Eisley',
+    reserverAddressStreet: 'Cantina street 3B',
+    reserverAddressZip: '12345',
+    reserverEmailAddress: 'luke@sky.com',
+    reserverName: 'Luke Skywalker',
+    reserverPhoneNumber: '1234567',
+  });
+  const defaultProps = {
+    actions: {
+      closeReservationInfoModal: simple.stub(),
+    },
+    show: true,
+    reservationsToShow: Immutable([reservation]),
+    resources: Immutable({ [resource.id]: resource }),
+  };
+
+  function getWrapper(extraProps = {}) {
+    return shallow(<ReservationInfoModal {...defaultProps} {...extraProps} />);
+  }
+
+  describe('render', () => {
+    const wrapper = getWrapper();
+
+    it('should render a Modal component', () => {
+      const modalComponent = wrapper.find(Modal);
+
+      expect(modalComponent.length).to.equal(1);
+    });
+
+    describe('Modal header', () => {
+      const modalHeader = wrapper.find(Modal.Header);
+
+      it('should render a ModalHeader component', () => {
+        expect(modalHeader.length).to.equal(1);
+      });
+
+      it('should contain a close button', () => {
+        expect(modalHeader.props().closeButton).to.equal(true);
+      });
+
+      it('should render a ModalTitle component', () => {
+        const modalTitle = wrapper.find(Modal.Title);
+
+        expect(modalTitle.length).to.equal(1);
+      });
+
+      it('the ModalTitle should display text "Varauksen tiedot"', () => {
+        const modalTitle = wrapper.find(Modal.Title);
+
+        expect(modalTitle.props().children).to.equal('Varauksen tiedot');
+      });
+    });
+
+    describe('Modal body', () => {
+      const modalBody = wrapper.find(Modal.Body);
+
+      it('should render a ModalBody component', () => {
+        expect(modalBody.length).to.equal(1);
+      });
+
+      describe('reservation data', () => {
+        const dl = wrapper.find('dl');
+        const dlText = dl.text();
+
+        it('should render a definition list', () => {
+          expect(dl.length).to.equal(1);
+        });
+
+        it('should render reservation.billingAddressCity', () => {
+          expect(dlText).to.contain(reservation.billingAddressCity);
+        });
+
+        it('should render reservation.billingAddressStreet', () => {
+          expect(dlText).to.contain(reservation.billingAddressStreet);
+        });
+
+        it('should render reservation.billingAddressZip', () => {
+          expect(dlText).to.contain(reservation.billingAddressZip);
+        });
+
+        it('should render reservation.businessId', () => {
+          expect(dlText).to.contain(reservation.businessId);
+        });
+
+        it('should render reservation.company', () => {
+          expect(dlText).to.contain(reservation.company);
+        });
+
+        it('should render reservation.eventDescription', () => {
+          expect(dlText).to.contain(reservation.eventDescription);
+        });
+
+        it('should render reservation.numberOfParticipants', () => {
+          expect(dlText).to.contain(reservation.numberOfParticipants);
+        });
+
+        it('should render reservation.reserverAddressCity', () => {
+          expect(dlText).to.contain(reservation.reserverAddressCity);
+        });
+
+        it('should render reservation.reserverAddressStreet', () => {
+          expect(dlText).to.contain(reservation.reserverAddressStreet);
+        });
+
+        it('should render reservation.reserverAddressZip', () => {
+          expect(dlText).to.contain(reservation.reserverAddressZip);
+        });
+
+        it('should render reservation.reserverEmailAddress', () => {
+          expect(dlText).to.contain(reservation.reserverEmailAddress);
+        });
+
+        it('should render reservation.reserverName', () => {
+          expect(dlText).to.contain(reservation.reserverName);
+        });
+
+        it('should render reservation.reserverPhoneNumber', () => {
+          expect(dlText).to.contain(reservation.reserverPhoneNumber);
+        });
+
+        it('should not render reservation.comments', () => {
+          expect(dlText).to.not.contain(reservation.comments);
+        });
+      });
+
+      describe('comments input', () => {
+        const input = wrapper.find(Input);
+        it('should render textarea input for comments', () => {
+          expect(input.length).to.equal(1);
+          expect(input.props().type).to.equal('textarea');
+        });
+
+        it('should have reservation.comments as default value', () => {
+          expect(input.props().defaultValue).to.equal(reservation.comments);
+        });
+      });
+    });
+
+    describe('Modal footer', () => {
+      const modalFooter = wrapper.find(Modal.Footer);
+
+      it('should render a ModalFooter component', () => {
+        expect(modalFooter.length).to.equal(1);
+      });
+
+      describe('Footer buttons', () => {
+        const buttons = modalFooter.find(Button);
+
+        it('should render one Button', () => {
+          expect(buttons.length).to.equal(1);
+        });
+
+        describe('Cancel button', () => {
+          const button = buttons.at(0);
+
+          it('the first button should read "Takaisin"', () => {
+            expect(button.props().children).to.equal('Takaisin');
+          });
+
+          it('clicking it should call closeReservationInfoModal', () => {
+            defaultProps.actions.closeReservationInfoModal.reset();
+            button.props().onClick();
+
+            expect(defaultProps.actions.closeReservationInfoModal.callCount).to.equal(1);
+          });
+        });
+      });
+    });
+  });
+});

--- a/app/containers/__tests__/ReservationInfoModal.spec.js
+++ b/app/containers/__tests__/ReservationInfoModal.spec.js
@@ -35,10 +35,12 @@ describe('Container: ReservationInfoModal', () => {
   const defaultProps = {
     actions: {
       closeReservationInfoModal: simple.stub(),
+      putReservation: simple.stub(),
     },
-    show: true,
+    isEditingReservations: false,
     reservationsToShow: Immutable([reservation]),
     resources: Immutable({ [resource.id]: resource }),
+    show: true,
   };
 
   function getWrapper(extraProps = {}) {
@@ -173,8 +175,8 @@ describe('Container: ReservationInfoModal', () => {
       describe('Footer buttons', () => {
         const buttons = modalFooter.find(Button);
 
-        it('should render one Button', () => {
-          expect(buttons.length).to.equal(1);
+        it('should render two Button', () => {
+          expect(buttons.length).to.equal(2);
         });
 
         describe('Cancel button', () => {
@@ -191,7 +193,50 @@ describe('Container: ReservationInfoModal', () => {
             expect(defaultProps.actions.closeReservationInfoModal.callCount).to.equal(1);
           });
         });
+
+        describe('Save button', () => {
+          const button = buttons.at(1);
+
+          it('the second button should read "Tallenna"', () => {
+            expect(button.props().children).to.equal('Tallenna');
+          });
+
+          it('should have handleSave as its onClick prop', () => {
+            const instance = wrapper.instance();
+            expect(button.props().onClick).to.equal(instance.handleSave);
+          });
+        });
       });
+    });
+  });
+
+  describe('handleSave', () => {
+    let updatedComments;
+
+    before(() => {
+      updatedComments = 'Updated comments';
+      const instance = getWrapper().instance();
+      instance.refs = {
+        commentsInput: { getValue: () => updatedComments },
+      };
+      defaultProps.actions.closeReservationInfoModal.reset();
+      defaultProps.actions.putReservation.reset();
+      instance.handleSave();
+    });
+
+    it('should call putReservation for the first reservation in reservationsToShow', () => {
+      expect(defaultProps.actions.putReservation.callCount).to.equal(1);
+    });
+
+    it('should call putReservation with correct arguments', () => {
+      const actualArgs = defaultProps.actions.putReservation.lastCall.args;
+      const expected = Object.assign({}, reservation, { comments: updatedComments });
+
+      expect(actualArgs[0]).to.deep.equal(expected);
+    });
+
+    it('should close the ReservationInfoModal', () => {
+      expect(defaultProps.actions.closeReservationInfoModal.callCount).to.equal(1);
     });
   });
 });

--- a/app/selectors/containers/__tests__/reservationInfoModalSelector.spec.js
+++ b/app/selectors/containers/__tests__/reservationInfoModalSelector.spec.js
@@ -8,6 +8,10 @@ describe('Selector: reservationInfoModalSelector', () => {
   const props = getDefaultRouterProps();
   const selected = reservationInfoModalSelector(state, props);
 
+  it('should return isEditingReservations', () => {
+    expect(selected.isEditingReservations).to.exist;
+  });
+
   it('should return show', () => {
     expect(selected.show).to.exist;
   });

--- a/app/selectors/containers/reservationInfoModalSelector.js
+++ b/app/selectors/containers/reservationInfoModalSelector.js
@@ -1,21 +1,26 @@
 import { createSelector } from 'reselect';
 
+import ActionTypes from 'constants/ActionTypes';
 import ModalTypes from 'constants/ModalTypes';
 import modalIsOpenSelectorFactory from 'selectors/factories/modalIsOpenSelectorFactory';
+import requestIsActiveSelectorFactory from 'selectors/factories/requestIsActiveSelectorFactory';
 
 const toShowSelector = (state) => state.ui.reservation.toShow;
 const resourcesSelector = (state) => state.data.resources;
 
 const reservationInfoModalSelector = createSelector(
   modalIsOpenSelectorFactory(ModalTypes.RESERVATION_INFO),
+  requestIsActiveSelectorFactory(ActionTypes.API.RESERVATION_PUT_REQUEST),
   resourcesSelector,
   toShowSelector,
   (
     reservationInfoModalIsOpen,
+    isEditingReservations,
     resources,
     reservationsToShow
   ) => {
     return {
+      isEditingReservations,
       reservationsToShow,
       resources,
       show: reservationInfoModalIsOpen,


### PR DESCRIPTION
This PR:
- Adds comments input to reservation info modal.
- Makes it possible for admins to edit reservation comments from the reservation info modal.
- Adds tests for reservation info modal.

Closes #278.