### PR TITLE
Feature/279 preliminary reservations edit buttons

### DIFF
--- a/app/assets/styles/reservations-list.less
+++ b/app/assets/styles/reservations-list.less
@@ -57,12 +57,11 @@
     .buttons {
       button {
         width: 80px;
-        margin-right: 14px;
         margin-bottom: 14px;
       }
 
       button + button {
-        margin-right: 0;
+        margin-left: 14px;
       }
     }
 

--- a/app/components/reservation/ReservationControls.js
+++ b/app/components/reservation/ReservationControls.js
@@ -83,13 +83,13 @@ class ReservationControls extends Component {
       return isAdmin ? null : null;
 
     case 'confirmed':
-      return isAdmin ? [buttons.adminCancel] : [buttons.cancel];
+      return isAdmin ? [buttons.adminCancel, buttons.edit] : [buttons.cancel];
 
     case 'denied':
       return isAdmin ? null : null;
 
     case 'requested':
-      return isAdmin ? [buttons.confirm, buttons.deny] : [buttons.edit, buttons.cancel];
+      return isAdmin ? [buttons.confirm, buttons.deny, buttons.edit] : [buttons.edit, buttons.cancel];
 
     default:
       return null;

--- a/app/components/reservation/__tests__/ReservationControls.spec.js
+++ b/app/components/reservation/__tests__/ReservationControls.spec.js
@@ -29,7 +29,7 @@ describe('Component: reservation/ReservationControls', () => {
     return shallow(<ReservationControls {...props} />);
   }
 
-  describe('if isAdmin is true', () => {
+  describe('if user is an admin', () => {
     const isAdmin = true;
 
     describe('with regular reservation', () => {
@@ -75,8 +75,8 @@ describe('Component: reservation/ReservationControls', () => {
       const reservation = Reservation.build({ needManualConfirmation: true, state: 'requested' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
-      it('should render two buttons', () => {
-        expect(buttons.length).to.equal(2);
+      it('should render three buttons', () => {
+        expect(buttons.length).to.equal(3);
       });
 
       describe('the first button', () => {
@@ -108,6 +108,21 @@ describe('Component: reservation/ReservationControls', () => {
           expect(onDenyClick.callCount).to.equal(1);
         });
       });
+
+      describe('the third button', () => {
+        const button = buttons.at(2);
+
+        it('should be an edit button', () => {
+          expect(button.props().children).to.equal('Muokkaa');
+        });
+
+        it('clicking the button should call onEditClick', () => {
+          onEditClick.reset();
+          button.props().onClick();
+
+          expect(onEditClick.callCount).to.equal(1);
+        });
+      });
     });
 
     describe('with preliminary reservation in cancelled state', () => {
@@ -132,11 +147,11 @@ describe('Component: reservation/ReservationControls', () => {
       const reservation = Reservation.build({ needManualConfirmation: true, state: 'confirmed' });
       const buttons = getWrapper(reservation, isAdmin).find(Button);
 
-      it('should render one button', () => {
-        expect(buttons.length).to.equal(1);
+      it('should render two buttons', () => {
+        expect(buttons.length).to.equal(2);
       });
 
-      describe('the button', () => {
+      describe('the first button', () => {
         const button = buttons.at(0);
 
         it('should be a cancel button', () => {
@@ -150,10 +165,25 @@ describe('Component: reservation/ReservationControls', () => {
           expect(onCancelClick.callCount).to.equal(1);
         });
       });
+
+      describe('the second button', () => {
+        const button = buttons.at(1);
+
+        it('should be an edit button', () => {
+          expect(button.props().children).to.equal('Muokkaa');
+        });
+
+        it('clicking the button should call onEditClick', () => {
+          onEditClick.reset();
+          button.props().onClick();
+
+          expect(onEditClick.callCount).to.equal(1);
+        });
+      });
     });
   });
 
-  describe('if isAdmin is false', () => {
+  describe('if user is not an admin', () => {
     const isAdmin = false;
 
     describe('with regular reservation', () => {

--- a/app/containers/__tests__/ReservationInfoModal.spec.js
+++ b/app/containers/__tests__/ReservationInfoModal.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import queryString from 'query-string';
 import React from 'react';
 import Button from 'react-bootstrap/lib/Button';
 import Input from 'react-bootstrap/lib/Input';
@@ -36,6 +37,8 @@ describe('Container: ReservationInfoModal', () => {
     actions: {
       closeReservationInfoModal: simple.stub(),
       putReservation: simple.stub(),
+      selectReservationToEdit: simple.stub(),
+      updatePath: simple.stub(),
     },
     isEditingReservations: false,
     reservationsToShow: Immutable([reservation]),
@@ -175,8 +178,8 @@ describe('Container: ReservationInfoModal', () => {
       describe('Footer buttons', () => {
         const buttons = modalFooter.find(Button);
 
-        it('should render two Button', () => {
-          expect(buttons.length).to.equal(2);
+        it('should render three Button', () => {
+          expect(buttons.length).to.equal(3);
         });
 
         describe('Cancel button', () => {
@@ -194,10 +197,23 @@ describe('Container: ReservationInfoModal', () => {
           });
         });
 
-        describe('Save button', () => {
+        describe('Edit button', () => {
           const button = buttons.at(1);
 
-          it('the second button should read "Tallenna"', () => {
+          it('the second button should read "Muokkaa"', () => {
+            expect(button.props().children).to.equal('Muokkaa');
+          });
+
+          it('should have handleEdit as its onClick prop', () => {
+            const instance = wrapper.instance();
+            expect(button.props().onClick).to.equal(instance.handleEdit);
+          });
+        });
+
+        describe('Save button', () => {
+          const button = buttons.at(2);
+
+          it('the third button should read "Tallenna"', () => {
             expect(button.props().children).to.equal('Tallenna');
           });
 
@@ -207,6 +223,41 @@ describe('Container: ReservationInfoModal', () => {
           });
         });
       });
+    });
+  });
+
+  describe('handleEdit', () => {
+    before(() => {
+      const instance = getWrapper().instance();
+      defaultProps.actions.closeReservationInfoModal.reset();
+      defaultProps.actions.selectReservationToEdit.reset();
+      defaultProps.actions.updatePath.reset();
+      instance.handleEdit();
+    });
+
+    it('should call selectReservationToEdit with reservation and minPeriod', () => {
+      expect(defaultProps.actions.selectReservationToEdit.callCount).to.equal(1);
+      expect(
+        defaultProps.actions.selectReservationToEdit.lastCall.args[0]
+      ).to.deep.equal(
+        { reservation: reservation, minPeriod: resource.minPeriod }
+      );
+    });
+
+    it('should call the updatePath with correct url', () => {
+      const actualUrlArg = defaultProps.actions.updatePath.lastCall.args[0];
+      const query = queryString.stringify({
+        date: reservation.begin.split('T')[0],
+        time: reservation.begin,
+      });
+      const expectedUrl = `/resources/${reservation.resource}/reservation?${query}`;
+
+      expect(defaultProps.actions.updatePath.callCount).to.equal(1);
+      expect(actualUrlArg).to.equal(expectedUrl);
+    });
+
+    it('should close the ReservationInfoModal', () => {
+      expect(defaultProps.actions.closeReservationInfoModal.callCount).to.equal(1);
     });
   });
 


### PR DESCRIPTION
This PR:
- adds preliminary reservations edit buttons for admins to user reservations page.
- adds edit button to reservation info modal.

Closes #279. 
