### PR TITLE
Feature/280 admin quick reservation

### DIFF
--- a/app/assets/styles/confirm-reservation-modal.less
+++ b/app/assets/styles/confirm-reservation-modal.less
@@ -6,6 +6,12 @@
       padding: 20px;
     }
 
+    .is-admin-event-field {
+      .help-block {
+        margin-left: 20px;
+      }
+    }
+
     .form-controls {
       .modal-footer();
       padding-right: 0;

--- a/app/assets/styles/confirm-reservation-modal.less
+++ b/app/assets/styles/confirm-reservation-modal.less
@@ -6,7 +6,7 @@
       padding: 20px;
     }
 
-    .is-admin-event-field {
+    .staff-event-field {
       .help-block {
         margin-left: 20px;
       }

--- a/app/components/reservation/ConfirmReservationModal.js
+++ b/app/components/reservation/ConfirmReservationModal.js
@@ -33,6 +33,7 @@ class ConfirmReservationModal extends Component {
 
     if (isAdmin) {
       formFields.push('comments');
+      formFields.push('isAdminEvent');
     }
 
     return formFields;

--- a/app/components/reservation/ConfirmReservationModal.js
+++ b/app/components/reservation/ConfirmReservationModal.js
@@ -33,7 +33,7 @@ class ConfirmReservationModal extends Component {
 
     if (isAdmin) {
       formFields.push('comments');
-      formFields.push('isAdminEvent');
+      formFields.push('staffEvent');
     }
 
     return formFields;

--- a/app/components/reservation/ConfirmReservationModal.js
+++ b/app/components/reservation/ConfirmReservationModal.js
@@ -33,7 +33,9 @@ class ConfirmReservationModal extends Component {
 
     if (isAdmin) {
       formFields.push('comments');
-      formFields.push('staffEvent');
+      if (resource.needManualConfirmation) {
+        formFields.push('staffEvent');
+      }
     }
 
     return formFields;

--- a/app/components/reservation/__tests__/ConfirmReservationModal.spec.js
+++ b/app/components/reservation/__tests__/ConfirmReservationModal.spec.js
@@ -1,11 +1,15 @@
 import { expect } from 'chai';
+import { shallow } from 'enzyme';
 import React from 'react';
 import sd from 'skin-deep';
 import simple from 'simple-mock';
 
+import forEach from 'lodash/collection/forEach';
 import Immutable from 'seamless-immutable';
 
 import ConfirmReservationModal from 'components/reservation/ConfirmReservationModal';
+import { RESERVATION_FORM_FIELDS } from 'constants/AppConstants';
+import ReservationForm from 'containers/ReservationForm';
 import Reservation from 'fixtures/Reservation';
 import Resource from 'fixtures/Resource';
 
@@ -256,6 +260,104 @@ describe('Component: reservation/ConfirmReservationModal', () => {
         timeRangeTrees.forEach((timeRangeTree, index) => {
           expect(timeRangeTree.props.begin).to.equal(props.selectedReservations[index].begin);
           expect(timeRangeTree.props.end).to.equal(props.selectedReservations[index].end);
+        });
+      });
+    });
+  });
+
+  describe('rendering ReservationForm', () => {
+    function getForm(needManualConfirmation = false, isAdmin = false) {
+      const resource = Resource.build({
+        needManualConfirmation,
+        userPermissions: { isAdmin },
+      });
+      const props = getProps({ resource });
+      const wrapper = shallow(<ConfirmReservationModal {...props} />);
+      return wrapper.find(ReservationForm);
+    }
+
+    describe('if resource needs manual confirmation', () => {
+      const needManualConfirmation = true;
+      describe('if user is an admin', () => {
+        const isAdmin = true;
+        const form = getForm(needManualConfirmation, isAdmin);
+        const formFields = form.props().fields;
+
+        it('form fields should include staffEvent', () => {
+          expect(formFields).to.contain('staffEvent');
+        });
+
+        it('form fields should include comments', () => {
+          expect(formFields).to.contain('comments');
+        });
+
+        it('form fields should include RESERVATION_FORM_FIELDS', () => {
+          forEach(RESERVATION_FORM_FIELDS, (field) => {
+            expect(formFields).to.contain(field);
+          });
+        });
+      });
+
+      describe('if user is a regular user', () => {
+        const isAdmin = false;
+        const form = getForm(needManualConfirmation, isAdmin);
+        const formFields = form.props().fields;
+
+        it('form fields should not include staffEvent', () => {
+          expect(formFields).to.not.contain('staffEvent');
+        });
+
+        it('form fields should not include comments', () => {
+          expect(formFields).to.not.contain('comments');
+        });
+
+        it('form fields should include RESERVATION_FORM_FIELDS', () => {
+          forEach(RESERVATION_FORM_FIELDS, (field) => {
+            expect(formFields).to.contain(field);
+          });
+        });
+      });
+    });
+
+    describe('if resource does not need manual confirmation', () => {
+      const needManualConfirmation = false;
+      describe('if user is an admin', () => {
+        const isAdmin = true;
+        const form = getForm(needManualConfirmation, isAdmin);
+        const formFields = form.props().fields;
+
+        it('form fields should not include staffEvent', () => {
+          expect(formFields).to.not.contain('staffEvent');
+        });
+
+        it('form fields should include comments', () => {
+          expect(formFields).to.contain('comments');
+        });
+
+        it('form fields should not include RESERVATION_FORM_FIELDS', () => {
+          forEach(RESERVATION_FORM_FIELDS, (field) => {
+            expect(formFields).to.not.contain(field);
+          });
+        });
+      });
+
+      describe('if user is a regular user', () => {
+        const isAdmin = false;
+        const form = getForm(needManualConfirmation, isAdmin);
+        const formFields = form.props().fields;
+
+        it('form fields should not include staffEvent', () => {
+          expect(formFields).to.not.contain('staffEvent');
+        });
+
+        it('form fields should not include comments', () => {
+          expect(formFields).to.not.contain('comments');
+        });
+
+        it('form fields should not include RESERVATION_FORM_FIELDS', () => {
+          forEach(RESERVATION_FORM_FIELDS, (field) => {
+            expect(formFields).to.not.contain(field);
+          });
         });
       });
     });

--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -13,6 +13,10 @@ export default {
     'Accept-Language': 'fi',
     'Content-Type': 'application/json',
   },
+  REQUIRED_ADMIN_EVENT_FIELDS: [
+    'eventDescription',
+    'reserverName',
+  ],
   RESERVATION_FORM_FIELDS: [
     'reserverName',
     'reserverEmailAddress',

--- a/app/constants/AppConstants.js
+++ b/app/constants/AppConstants.js
@@ -13,7 +13,7 @@ export default {
     'Accept-Language': 'fi',
     'Content-Type': 'application/json',
   },
-  REQUIRED_ADMIN_EVENT_FIELDS: [
+  REQUIRED_STAFF_EVENT_FIELDS: [
     'eventDescription',
     'reserverName',
   ],

--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -76,6 +76,26 @@ export class UnconnectedReservationForm extends Component {
     );
   }
 
+  renderIsAdminEventField(field) {
+    if (!field) {
+      return null;
+    }
+    return (
+      <Well>
+        <Input
+          {...field}
+          help={`
+            Viraston oma tapahtuma hyväksytään automaattisesti ja ainoat pakolliset tiedot
+            ovat varaajan nimi ja tilaisuuden kuvaus.
+          `}
+          label="Viraston oma tapahtuma"
+          type="checkbox"
+          wrapperClassName="col-md-12 is-admin-event-field"
+        />
+      </Well>
+    );
+  }
+
   render() {
     const {
       fields,
@@ -87,6 +107,7 @@ export class UnconnectedReservationForm extends Component {
     return (
       <div>
         <form className="reservation-form form-horizontal">
+          {this.renderIsAdminEventField(fields.isAdminEvent)}
           {this.renderField('text', 'Nimi', fields.reserverName)}
           {this.renderField('email', 'Sähköposti', fields.reserverEmailAddress)}
           {this.renderField('text', 'Puhelin', fields.reserverPhoneNumber)}

--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -6,6 +6,7 @@ import Well from 'react-bootstrap/lib/Well';
 import { reduxForm } from 'redux-form';
 
 import isEmail from 'validator/lib/isEmail';
+import { REQUIRED_ADMIN_EVENT_FIELDS } from 'constants/AppConstants';
 
 const validators = {
   reserverEmailAddress: ({ reserverEmailAddress }) => {
@@ -32,6 +33,7 @@ const maxLengths = {
 
 export function validate(values, { fields, requiredFields }) {
   const errors = {};
+  const currentRequiredFields = values.isAdminEvent ? REQUIRED_ADMIN_EVENT_FIELDS : requiredFields;
   fields.forEach((field) => {
     const validator = validators[field];
     if (validator) {
@@ -45,7 +47,7 @@ export function validate(values, { fields, requiredFields }) {
         errors[field] = `Kentän maksimipituus on ${maxLengths[field]} merkkiä`;
       }
     }
-    if (includes(requiredFields, field)) {
+    if (includes(currentRequiredFields, field)) {
       if (!values[field]) {
         errors[field] = 'Pakollinen tieto';
       }
@@ -60,7 +62,7 @@ export class UnconnectedReservationForm extends Component {
       return null;
     }
     const hasError = field.error && field.touched;
-    const isRequired = includes(this.props.requiredFields, field.name);
+    const isRequired = includes(this.requiredFields, field.name);
 
     return (
       <Input
@@ -103,7 +105,13 @@ export class UnconnectedReservationForm extends Component {
       handleSubmit,
       onClose,
       onConfirm,
+      requiredFields,
     } = this.props;
+
+    this.requiredFields = fields.isAdminEvent && fields.isAdminEvent.checked ?
+      REQUIRED_ADMIN_EVENT_FIELDS :
+      requiredFields;
+
     return (
       <div>
         <form className="reservation-form form-horizontal">

--- a/app/containers/ReservationForm.js
+++ b/app/containers/ReservationForm.js
@@ -6,7 +6,7 @@ import Well from 'react-bootstrap/lib/Well';
 import { reduxForm } from 'redux-form';
 
 import isEmail from 'validator/lib/isEmail';
-import { REQUIRED_ADMIN_EVENT_FIELDS } from 'constants/AppConstants';
+import { REQUIRED_STAFF_EVENT_FIELDS } from 'constants/AppConstants';
 
 const validators = {
   reserverEmailAddress: ({ reserverEmailAddress }) => {
@@ -33,7 +33,7 @@ const maxLengths = {
 
 export function validate(values, { fields, requiredFields }) {
   const errors = {};
-  const currentRequiredFields = values.isAdminEvent ? REQUIRED_ADMIN_EVENT_FIELDS : requiredFields;
+  const currentRequiredFields = values.staffEvent ? REQUIRED_STAFF_EVENT_FIELDS : requiredFields;
   fields.forEach((field) => {
     const validator = validators[field];
     if (validator) {
@@ -78,7 +78,7 @@ export class UnconnectedReservationForm extends Component {
     );
   }
 
-  renderIsAdminEventField(field) {
+  renderStaffEventField(field) {
     if (!field) {
       return null;
     }
@@ -92,7 +92,7 @@ export class UnconnectedReservationForm extends Component {
           `}
           label="Viraston oma tapahtuma"
           type="checkbox"
-          wrapperClassName="col-md-12 is-admin-event-field"
+          wrapperClassName="col-md-12 staff-event-field"
         />
       </Well>
     );
@@ -108,14 +108,14 @@ export class UnconnectedReservationForm extends Component {
       requiredFields,
     } = this.props;
 
-    this.requiredFields = fields.isAdminEvent && fields.isAdminEvent.checked ?
-      REQUIRED_ADMIN_EVENT_FIELDS :
+    this.requiredFields = fields.staffEvent && fields.staffEvent.checked ?
+      REQUIRED_STAFF_EVENT_FIELDS :
       requiredFields;
 
     return (
       <div>
         <form className="reservation-form form-horizontal">
-          {this.renderIsAdminEventField(fields.isAdminEvent)}
+          {this.renderStaffEventField(fields.staffEvent)}
           {this.renderField('text', 'Nimi', fields.reserverName)}
           {this.renderField('email', 'Sähköposti', fields.reserverEmailAddress)}
           {this.renderField('text', 'Puhelin', fields.reserverPhoneNumber)}

--- a/app/containers/__tests__/ReservationForm.spec.js
+++ b/app/containers/__tests__/ReservationForm.spec.js
@@ -7,7 +7,7 @@ import Button from 'react-bootstrap/lib/Button';
 import Input from 'react-bootstrap/lib/Input';
 
 import {
-  REQUIRED_ADMIN_EVENT_FIELDS,
+  REQUIRED_STAFF_EVENT_FIELDS,
   RESERVATION_FORM_FIELDS,
 } from 'constants/AppConstants';
 
@@ -19,10 +19,10 @@ import {
 describe('Container: ReservationForm', () => {
   describe('validation', () => {
     describe('if field value is missing', () => {
-      describe('if user is reserving an admin event', () => {
-        const values = { isAdminEvent: true };
-        it('should return an error if field belongs to REQUIRED_ADMIN_EVENT_FIELDS', () => {
-          const fieldName = REQUIRED_ADMIN_EVENT_FIELDS[0];
+      describe('if user is reserving an staff event', () => {
+        const values = { staffEvent: true };
+        it('should return an error if field belongs to REQUIRED_STAFF_EVENT_FIELDS', () => {
+          const fieldName = REQUIRED_STAFF_EVENT_FIELDS[0];
           const props = {
             fields: [fieldName],
             requiredFields: [],
@@ -31,7 +31,7 @@ describe('Container: ReservationForm', () => {
           expect(errors[fieldName]).to.exist;
         });
 
-        it('should not return an error if field does not belong to REQUIRED_ADMIN_EVENT_FIELDS', () => {
+        it('should not return an error if field does not belong to REQUIRED_STAFF_EVENT_FIELDS', () => {
           const fieldName = 'someField';
           const props = {
             fields: [fieldName],
@@ -152,11 +152,11 @@ describe('Container: ReservationForm', () => {
             expect(input.props().label).to.not.contain('*');
           });
 
-          describe('if isAdminEvent checkbox is checked', () => {
-            const defaultFields = { isAdminEvent: { name: 'isAdminEvent', checked: true } };
+          describe('if staffEvent checkbox is checked', () => {
+            const defaultFields = { staffEvent: { name: 'staffEvent', checked: true } };
 
-            it('should show an asterisk beside REQUIRED_ADMIN_EVENT_FIELDS', () => {
-              const fieldName = REQUIRED_ADMIN_EVENT_FIELDS[0];
+            it('should show an asterisk beside REQUIRED_STAFF_EVENT_FIELDS', () => {
+              const fieldName = REQUIRED_STAFF_EVENT_FIELDS[0];
               const fields = Object.assign({}, defaultFields, { [fieldName]: { name: fieldName } });
               const props = {
                 fields,
@@ -166,7 +166,7 @@ describe('Container: ReservationForm', () => {
               expect(input.props().label).to.contain('*');
             });
 
-            it('should not show an asterisk beside non REQUIRED_ADMIN_EVENT_FIELDS', () => {
+            it('should not show an asterisk beside non REQUIRED_STAFF_EVENT_FIELDS', () => {
               const fieldName = RESERVATION_FORM_FIELDS[1];
               const fields = Object.assign({}, defaultFields, { [fieldName]: { name: fieldName } });
               const props = {

--- a/app/containers/__tests__/ReservationForm.spec.js
+++ b/app/containers/__tests__/ReservationForm.spec.js
@@ -4,6 +4,12 @@ import React from 'react';
 import simple from 'simple-mock';
 
 import Button from 'react-bootstrap/lib/Button';
+import Input from 'react-bootstrap/lib/Input';
+
+import {
+  REQUIRED_ADMIN_EVENT_FIELDS,
+  RESERVATION_FORM_FIELDS,
+} from 'constants/AppConstants';
 
 import {
   UnconnectedReservationForm as ReservationForm,
@@ -12,33 +18,59 @@ import {
 
 describe('Container: ReservationForm', () => {
   describe('validation', () => {
-    describe('if field is in required fields', () => {
-      const props = {
-        fields: ['name'],
-        requiredFields: ['name'],
-      };
+    describe('if field value is missing', () => {
+      describe('if user is reserving an admin event', () => {
+        const values = { isAdminEvent: true };
+        it('should return an error if field belongs to REQUIRED_ADMIN_EVENT_FIELDS', () => {
+          const fieldName = REQUIRED_ADMIN_EVENT_FIELDS[0];
+          const props = {
+            fields: [fieldName],
+            requiredFields: [],
+          };
+          const errors = validate(values, props);
+          expect(errors[fieldName]).to.exist;
+        });
 
-      it('should return an error if field value is missing', () => {
-        const values = {};
-        const errors = validate(values, props);
-        expect(errors.name).to.exist;
+        it('should not return an error if field does not belong to REQUIRED_ADMIN_EVENT_FIELDS', () => {
+          const fieldName = 'someField';
+          const props = {
+            fields: [fieldName],
+            requiredFields: [],
+          };
+          const errors = validate(values, props);
+          expect(errors[fieldName]).to.not.exist;
+        });
       });
 
-      it('should not return an error if field has value', () => {
-        const values = { name: 'Luke' };
-        const errors = validate(values, props);
-        expect(errors.name).to.not.exist;
+      describe('if user is reserving a regular event', () => {
+        const values = {};
+
+        it('should return an error if field is in requiredFields', () => {
+          const fieldName = 'someField';
+          const props = {
+            fields: [fieldName],
+            requiredFields: [fieldName],
+          };
+          const errors = validate(values, props);
+          expect(errors[fieldName]).to.exist;
+        });
+
+        it('should not return an error if field is not in requiredFields', () => {
+          const fieldName = 'someField';
+          const props = {
+            fields: [fieldName],
+            requiredFields: [],
+          };
+          const errors = validate(values, props);
+          expect(errors[fieldName]).to.not.exist;
+        });
       });
     });
 
-    describe('if field is not in required fields', () => {
-      const props = {
-        fields: ['name'],
-        requiredFields: [],
-      };
-
-      it('should not return an error if field value is missing', () => {
-        const values = {};
+    describe('if field has a value', () => {
+      it('should not return an error even if field is required', () => {
+        const props = { fields: ['name'], requiredFields: ['name'] };
+        const values = { name: 'Luke' };
         const errors = validate(values, props);
         expect(errors.name).to.not.exist;
       });
@@ -65,30 +97,102 @@ describe('Container: ReservationForm', () => {
   });
 
   describe('rendering', () => {
-    const fields = {
-      name: {},
-      email: {},
-      phone: {},
-      description: {},
-      address: {},
-    };
-    const props = {
-      fields,
+    const defaultProps = {
+      fields: {},
       handleSubmit: simple.mock(),
       isMakingReservations: false,
       onClose: simple.mock(),
       onConfirm: simple.mock(),
       requiredFields: [],
     };
-    const wrapper = shallow(<ReservationForm {...props} />);
+
+    function getWrapper(extraProps) {
+      return shallow(<ReservationForm {...defaultProps} {...extraProps} />);
+    }
 
     it('should render a form', () => {
-      const form = wrapper.find('form');
+      const form = getWrapper().find('form');
       expect(form.length).to.equal(1);
     });
 
+    describe('form fields', () => {
+      describe('fields included in RESERVATION_FORM_FIELDS', () => {
+        it('should render a field if it is included in props.fields', () => {
+          const fields = {
+            [RESERVATION_FORM_FIELDS[0]]: {},
+          };
+          const input = getWrapper({ fields }).find(Input);
+          expect(input.length).to.equal(1);
+        });
+
+        it('should not render a field if it is not included in props.fields', () => {
+          const fields = {};
+          const input = getWrapper({ fields }).find(Input);
+          expect(input.length).to.equal(0);
+        });
+
+        describe('required fields', () => {
+          it('should display an asterisk beside a required field label', () => {
+            const fieldName = RESERVATION_FORM_FIELDS[0];
+            const props = {
+              fields: { [fieldName]: { name: fieldName } },
+              requiredFields: [fieldName],
+            };
+            const input = getWrapper(props).find(Input);
+            expect(input.props().label).to.contain('*');
+          });
+
+          it('should not display an asterisk beside a non required field label', () => {
+            const fieldName = RESERVATION_FORM_FIELDS[0];
+            const props = {
+              fields: { [fieldName]: { name: fieldName } },
+              requiredFields: [],
+            };
+            const input = getWrapper(props).find(Input);
+            expect(input.props().label).to.not.contain('*');
+          });
+
+          describe('if isAdminEvent checkbox is checked', () => {
+            const defaultFields = { isAdminEvent: { name: 'isAdminEvent', checked: true } };
+
+            it('should show an asterisk beside REQUIRED_ADMIN_EVENT_FIELDS', () => {
+              const fieldName = REQUIRED_ADMIN_EVENT_FIELDS[0];
+              const fields = Object.assign({}, defaultFields, { [fieldName]: { name: fieldName } });
+              const props = {
+                fields,
+                requiredFields: [fieldName],
+              };
+              const input = getWrapper(props).find(Input).at(1);
+              expect(input.props().label).to.contain('*');
+            });
+
+            it('should not show an asterisk beside non REQUIRED_ADMIN_EVENT_FIELDS', () => {
+              const fieldName = RESERVATION_FORM_FIELDS[1];
+              const fields = Object.assign({}, defaultFields, { [fieldName]: { name: fieldName } });
+              const props = {
+                fields,
+                requiredFields: [fieldName],
+              };
+              const input = getWrapper(props).find(Input).at(1);
+              expect(input.props().label).to.not.contain('*');
+            });
+          });
+        });
+      });
+
+      describe('fields not included in RESERVATION_FORM_FIELDS', () => {
+        it('should not render a field even if it is included in props.fields', () => {
+          const fields = {
+            someOtherField: {},
+          };
+          const input = getWrapper({ fields }).find(Input);
+          expect(input.length).to.equal(0);
+        });
+      });
+    });
+
     describe('form buttons', () => {
-      const buttons = wrapper.find(Button);
+      const buttons = getWrapper().find(Button);
 
       it('should render two buttons', () => {
         expect(buttons.length).to.equal(2);
@@ -102,10 +206,10 @@ describe('Container: ReservationForm', () => {
         });
 
         it('clicking it should call props.onClose', () => {
-          props.onClose.reset();
+          defaultProps.onClose.reset();
           button.props().onClick();
 
-          expect(props.onClose.callCount).to.equal(1);
+          expect(defaultProps.onClose.callCount).to.equal(1);
         });
       });
 


### PR DESCRIPTION
This PR adds a possibility for admins to make staff event reservations. Those events are accepted automatically and require only reserver name and event description to be specified.
