### PR TITLE
Use unit.municipality in addresses

### DIFF
--- a/app/utils/DataUtils.js
+++ b/app/utils/DataUtils.js
@@ -8,6 +8,7 @@ import sortBy from 'lodash/collection/sortBy';
 import clone from 'lodash/lang/clone';
 import isEmpty from 'lodash/lang/isEmpty';
 import camelCase from 'lodash/string/camelCase';
+import capitalize from 'lodash/string/capitalize';
 import moment from 'moment';
 
 import { REQUIRED_STAFF_EVENT_FIELDS } from 'constants/AppConstants';
@@ -62,7 +63,7 @@ function getAddress(item) {
 
   const streetAddress = item.streetAddress ? item.streetAddress.fi : '';
   const zip = item.addressZip;
-  const city = 'Helsinki';
+  const city = capitalize(item.municipality);
 
   return `${streetAddress}, ${zip} ${city}`;
 }

--- a/app/utils/__tests__/DataUtils.spec.js
+++ b/app/utils/__tests__/DataUtils.spec.js
@@ -146,9 +146,21 @@ describe('Utils: DataUtils', () => {
     it('should return the address in proper format', () => {
       const item = {
         addressZip: '12345',
+        municipality: 'Helsinki',
         streetAddress: { fi: 'Example street 3' },
       };
       const expected = 'Example street 3, 12345 Helsinki';
+
+      expect(getAddress(item)).to.equal(expected);
+    });
+
+    it('should capitalize the municipality', () => {
+      const item = {
+        addressZip: '12345',
+        municipality: 'espoo',
+        streetAddress: { fi: 'Example street 3' },
+      };
+      const expected = 'Example street 3, 12345 Espoo';
 
       expect(getAddress(item)).to.equal(expected);
     });
@@ -171,6 +183,7 @@ describe('Utils: DataUtils', () => {
       const item = {
         addressZip: '12345',
         name: { fi: 'Some Unit' },
+        municipality: 'Helsinki',
         streetAddress: { fi: 'Example street 3' },
       };
       const expected = 'Some Unit, Example street 3, 12345 Helsinki';


### PR DESCRIPTION
If provided shows the unit municipality in addresses. Otherwise uses Helsinki as the default city.