### PR TITLE
Fix wrong info in reservation info modal issue

### DIFF
--- a/app/reducers/__tests__/reservationsReducer.spec.js
+++ b/app/reducers/__tests__/reservationsReducer.spec.js
@@ -111,7 +111,6 @@ describe('Reducer: reservationsReducer', () => {
         const action = putReservationSuccess();
         const initialState = Immutable({
           selected: ['some-selected'],
-          toShow: [],
         });
         const nextState = reservationsReducer(initialState, action);
 
@@ -122,38 +121,20 @@ describe('Reducer: reservationsReducer', () => {
         const action = putReservationSuccess();
         const initialState = Immutable({
           toEdit: ['something-to-edit'],
-          toShow: [],
         });
         const nextState = reservationsReducer(initialState, action);
 
         expect(nextState.toEdit).to.deep.equal([]);
       });
 
-      it('should add the given reservation to toShow', () => {
+      it('should clear the toShow', () => {
+        const action = putReservationSuccess();
         const initialState = Immutable({
-          toShow: [],
+          toShow: ['something-to-show'],
         });
-        const reservation = Reservation.build();
-        const action = putReservationSuccess(reservation);
         const nextState = reservationsReducer(initialState, action);
-        const expected = Immutable([reservation]);
 
-        expect(nextState.toShow).to.deep.equal(expected);
-      });
-
-      it('should not affect other reservations in toShow', () => {
-        const reservations = [
-          Reservation.build(),
-          Reservation.build(),
-        ];
-        const initialState = Immutable({
-          toShow: [reservations[0]],
-        });
-        const action = putReservationSuccess(reservations[1]);
-        const nextState = reservationsReducer(initialState, action);
-        const expected = Immutable([reservations[0], reservations[1]]);
-
-        expect(nextState.toShow).to.deep.equal(expected);
+        expect(nextState.toShow).to.deep.equal([]);
       });
     });
 

--- a/app/reducers/reservationsReducer.js
+++ b/app/reducers/reservationsReducer.js
@@ -31,12 +31,19 @@ function selectReservationToEdit(state, action) {
 function reservationsReducer(state = initialState, action) {
   switch (action.type) {
 
-    case types.API.RESERVATION_POST_SUCCESS:
-    case types.API.RESERVATION_PUT_SUCCESS: {
+    case types.API.RESERVATION_POST_SUCCESS: {
       return state.merge({
         selected: [],
         toEdit: [],
         toShow: [...state.toShow, action.payload],
+      });
+    }
+
+    case types.API.RESERVATION_PUT_SUCCESS: {
+      return state.merge({
+        selected: [],
+        toEdit: [],
+        toShow: [],
       });
     }
 


### PR DESCRIPTION
Reservation PUT requests where causing the edited reservation to be put
into list of reservations to show in the info modal.
Closes #401.