### PR TITLE
Make the image of resource list item a link

### DIFF
--- a/app/screens/shared/resource-list/ResourceListItem.js
+++ b/app/screens/shared/resource-list/ResourceListItem.js
@@ -34,12 +34,17 @@ class ResourceListItem extends Component {
 
     return (
       <li className="resource-list-item">
-        <div
-          className="image-container"
-          style={this.getBackgroundImageStyles(getMainImage(resource.images))}
+        <Link
+          to={`/resources/${resource.id}`}
+          query={{ date: date.split('T')[0] }}
         >
-          <ResourceAvailability date={date} resource={resource} />
-        </div>
+          <div
+            className="image-container"
+            style={this.getBackgroundImageStyles(getMainImage(resource.images))}
+          >
+            <ResourceAvailability date={date} resource={resource} />
+          </div>
+        </Link>
         <div className="content">
           <div className="icons">
             {this.renderIcon('user', resource.peopleCapacity)}

--- a/app/screens/shared/resource-list/ResourceListItem.spec.js
+++ b/app/screens/shared/resource-list/ResourceListItem.spec.js
@@ -38,18 +38,18 @@ describe('screens/shared/resource-list/ResourceListItem', () => {
     expect(imageContainer.props().style.backgroundImage).to.contain(resourceImage.url);
   });
 
-  it('contains a link to resources page', () => {
-    const link = getWrapper().find(Link);
+  it('contains links to resources page', () => {
+    const links = getWrapper().find(Link);
 
-    expect(link.length).to.equal(1);
-    expect(link.props().to).to.contain('resources');
+    expect(links.length).to.equal(2);
+    expect(links.at(0).props().to).to.contain('resources');
   });
 
-  it('renders the name of the resource inside the link', () => {
-    const link = getWrapper().find(Link);
+  it('renders the name of the resource inside a h4 header', () => {
+    const header = getWrapper().find('h4');
     const expected = defaultProps.resource.name.fi;
 
-    expect(link.html()).to.contain(expected);
+    expect(header.html()).to.contain(expected);
   });
 
   it('renders the name of the given unit in props', () => {


### PR DESCRIPTION
Making the whole box a link is not possible since it already contains the reservation button that is another link to reservation page.

Closes #414.