### PR TITLE
Feature/438 own reservations in calendar

### DIFF
--- a/app/screens/resource/reservation-calendar/time-slots/TimeSlot.js
+++ b/app/screens/resource/reservation-calendar/time-slots/TimeSlot.js
@@ -29,6 +29,7 @@ class TimeSlot extends Component {
   constructor(props) {
     super(props);
     this.handleRowClick = this.handleRowClick.bind(this);
+    this.renderReservationControls = this.renderReservationControls.bind(this);
   }
 
   componentDidMount() {
@@ -72,6 +73,24 @@ class TimeSlot extends Component {
     }
   }
 
+  renderReservationControls() {
+    const {
+      isAdmin,
+      isStaff,
+      resource,
+      slot,
+    } = this.props;
+
+    return (
+      <ReservationControls
+        isAdmin={isAdmin}
+        isStaff={isStaff}
+        reservation={slot.reservation}
+        resource={resource}
+      />
+    );
+  }
+
   renderUserInfo(user) {
     if (!user) {
       return null;
@@ -87,7 +106,6 @@ class TimeSlot extends Component {
       isAdmin,
       isEditing,
       isLoggedIn,
-      isStaff,
       resource,
       selected,
       slot,
@@ -114,7 +132,7 @@ class TimeSlot extends Component {
           'is-admin': isAdmin,
           editing: slot.editing,
           past: isPast,
-          'own-reservation': reservation && reservation.isOwn,
+          'own-reservation': isOwnReservation,
           'reservation-starting': (isAdmin || isOwnReservation) && slot.reservationStarting,
           'reservation-ending': (isAdmin || isOwnReservation) && slot.reservationEnding,
           reserved: slot.reserved,
@@ -137,14 +155,7 @@ class TimeSlot extends Component {
         </td>
         {!isAdmin && (
           <td className="controls-cell">
-            {showReservationControls && isOwnReservation && (
-              <ReservationControls
-                isAdmin={isAdmin}
-                isStaff={isStaff}
-                reservation={reservation}
-                resource={resource}
-              />
-            )}
+            {showReservationControls && isOwnReservation && this.renderReservationControls()}
           </td>
         )}
         {isAdmin && (
@@ -159,14 +170,7 @@ class TimeSlot extends Component {
         )}
         {isAdmin && (
           <td className="controls-cell">
-            {showReservationControls && (
-              <ReservationControls
-                isAdmin={isAdmin}
-                isStaff={isStaff}
-                reservation={reservation}
-                resource={resource}
-              />
-            )}
+            {showReservationControls && this.renderReservationControls()}
           </td>
         )}
       </tr>

--- a/app/screens/resource/reservation-calendar/time-slots/TimeSlot.js
+++ b/app/screens/resource/reservation-calendar/time-slots/TimeSlot.js
@@ -8,6 +8,23 @@ import Label from 'react-bootstrap/lib/Label';
 import ReservationControls from 'containers/ReservationControls';
 import { scrollTo } from 'utils/domUtils';
 
+export function getLabelData({ isOwnReservation, isPast, slot }) {
+  let data = {};
+
+  if (slot.editing) {
+    data = { bsStyle: 'info', text: 'Muokataan' };
+  } else if (slot.reserved) {
+    data = {
+      bsStyle: isOwnReservation ? 'info' : 'danger',
+      text: isOwnReservation ? 'Oma varaus' : 'Varattu',
+    };
+  } else {
+    data = { bsStyle: 'success', text: 'Vapaa' };
+  }
+
+  return isPast ? { bsStyle: 'default', text: data.text } : data;
+}
+
 class TimeSlot extends Component {
   constructor(props) {
     super(props);
@@ -85,23 +102,10 @@ class TimeSlot extends Component {
     const reservation = slot.reservation;
     const isOwnReservation = reservation && reservation.isOwn;
     const showReservationControls = reservation && slot.reservationStarting && !isEditing;
-
-    let labelBsStyle;
-    let labelText;
-
-    if (slot.editing) {
-      labelBsStyle = 'info';
-      labelText = 'Muokataan';
-    } else if (slot.reserved) {
-      labelBsStyle = isOwnReservation ? 'info' : 'danger';
-      labelText = isOwnReservation ? 'Oma varaus' : 'Varattu';
-    } else {
-      labelBsStyle = 'success';
-      labelText = 'Vapaa';
-    }
-    if (isPast) {
-      labelBsStyle = 'default';
-    }
+    const {
+      bsStyle: labelBsStyle,
+      text: labelText,
+    } = getLabelData({ isOwnReservation, isPast, slot });
 
     return (
       <tr

--- a/app/screens/resource/reservation-calendar/time-slots/TimeSlot.js
+++ b/app/screens/resource/reservation-calendar/time-slots/TimeSlot.js
@@ -82,20 +82,26 @@ class TimeSlot extends Component {
       (!slot.editing && (slot.reserved || isPast))
     );
     const checked = selected || (slot.reserved && !slot.editing);
+    const reservation = slot.reservation;
+    const isOwnReservation = reservation && reservation.isOwn;
+    const showReservationControls = reservation && slot.reservationStarting && !isEditing;
+
     let labelBsStyle;
     let labelText;
-    if (isPast) {
-      labelBsStyle = 'default';
-    } else {
-      labelBsStyle = slot.reserved ? 'danger' : 'success';
-    }
+
     if (slot.editing) {
       labelBsStyle = 'info';
       labelText = 'Muokataan';
+    } else if (slot.reserved) {
+      labelBsStyle = isOwnReservation ? 'info' : 'danger';
+      labelText = isOwnReservation ? 'Oma varaus' : 'Varattu';
     } else {
-      labelText = slot.reserved ? 'Varattu' : 'Vapaa';
+      labelBsStyle = 'success';
+      labelText = 'Vapaa';
     }
-    const reservation = slot.reservation;
+    if (isPast) {
+      labelBsStyle = 'default';
+    }
 
     return (
       <tr
@@ -104,8 +110,9 @@ class TimeSlot extends Component {
           'is-admin': isAdmin,
           editing: slot.editing,
           past: isPast,
-          'reservation-starting': isAdmin && slot.reservationStarting,
-          'reservation-ending': isAdmin && slot.reservationEnding,
+          'own-reservation': reservation && reservation.isOwn,
+          'reservation-starting': (isAdmin || isOwnReservation) && slot.reservationStarting,
+          'reservation-ending': (isAdmin || isOwnReservation) && slot.reservationEnding,
           reserved: slot.reserved,
           selected,
         })}
@@ -124,6 +131,18 @@ class TimeSlot extends Component {
             {labelText}
           </Label>
         </td>
+        {!isAdmin && (
+          <td className="controls-cell">
+            {showReservationControls && isOwnReservation && (
+              <ReservationControls
+                isAdmin={isAdmin}
+                isStaff={isStaff}
+                reservation={reservation}
+                resource={resource}
+              />
+            )}
+          </td>
+        )}
         {isAdmin && (
           <td className="user-cell">
             {reservation && slot.reservationStarting && this.renderUserInfo(reservation.user)}
@@ -136,7 +155,7 @@ class TimeSlot extends Component {
         )}
         {isAdmin && (
           <td className="controls-cell">
-            {reservation && slot.reservationStarting && !isEditing && (
+            {showReservationControls && (
               <ReservationControls
                 isAdmin={isAdmin}
                 isStaff={isStaff}

--- a/app/screens/resource/reservation-calendar/time-slots/TimeSlot.spec.js
+++ b/app/screens/resource/reservation-calendar/time-slots/TimeSlot.spec.js
@@ -1,16 +1,18 @@
 import { expect } from 'chai';
+import { shallow } from 'enzyme';
 import React from 'react';
+import Glyphicon from 'react-bootstrap/lib/Glyphicon';
+import Label from 'react-bootstrap/lib/Label';
 import Immutable from 'seamless-immutable';
 import simple from 'simple-mock';
-import sd from 'skin-deep';
 
 import TimeSlotFixture from 'fixtures/TimeSlot';
 import Reservation from 'fixtures/Reservation';
 import Resource from 'fixtures/Resource';
 import TimeSlot from './TimeSlot';
 
-function getProps(props) {
-  const defaults = {
+describe('screens/resource/reservation-calendar/time-slots/TimeSlot', () => {
+  const defaultProps = {
     addNotification: simple.stub(),
     isAdmin: false,
     isEditing: true,
@@ -22,107 +24,97 @@ function getProps(props) {
     slot: Immutable(TimeSlotFixture.build()),
   };
 
-  return Object.assign({}, defaults, props);
-}
+  function getWrapper(extraProps) {
+    return shallow(<TimeSlot {...defaultProps} {...extraProps} />);
+  }
 
-describe('Component: reservation/TimeSlot', () => {
   describe('render', () => {
     describe('when the slot is not reserved', () => {
-      const props = getProps();
-      const tree = sd.shallowRender(<TimeSlot {...props} />);
-      const vdom = tree.getRenderOutput();
+      const wrapper = getWrapper();
 
-      it('should render a table row', () => {
-        expect(vdom.type).to.equal('tr');
+      it('renders a table row', () => {
+        const tableRow = wrapper.find('tr');
+
+        expect(tableRow.length).to.equal(1);
       });
 
-      it('clicking the table row should call props.onClick with correct arguments', () => {
-        tree.props.onClick();
+      it('clicking the table row calls props.onClick with correct arguments', () => {
+        wrapper.find('tr').props().onClick();
 
-        expect(props.onClick.callCount).to.equal(1);
+        expect(defaultProps.onClick.callCount).to.equal(1);
       });
 
       describe('table cells', () => {
-        const tdTrees = tree.everySubTree('td');
+        const tableCells = wrapper.find('td');
 
-        it('should render 3 table cells', () => {
-          expect(tdTrees).to.have.length(3);
+        it('renders 4 table cells', () => {
+          expect(tableCells).to.have.length(4);
         });
 
         describe('the first table cell', () => {
-          const tdTree = tdTrees[0];
-          const glyphiconTree = tdTree.subTree('Glyphicon');
+          const tableCell = tableCells.at(0);
+          const glyphIcon = tableCell.find(Glyphicon);
 
-          it('should render a checkbox icon', () => {
-            expect(glyphiconTree).to.be.ok;
+          it('renders a checkbox icon', () => {
+            expect(glyphIcon.length).to.equal(1);
           });
 
-          it('should not be checked if the slot is available', () => {
-            expect(glyphiconTree.props.glyph).to.equal('unchecked');
+          it('is not checked', () => {
+            expect(glyphIcon.props().glyph).to.equal('unchecked');
           });
         });
 
         describe('the second table cell', () => {
-          const tdTree = tdTrees[1];
+          const tableCell = tableCells.at(1);
 
-          it('should display the slot time range as string', () => {
-            expect(tdTree.text()).to.equal(props.slot.asString);
+          it('displays the slot time range as a string', () => {
+            expect(tableCell.text()).to.equal(defaultProps.slot.asString);
           });
 
-          it('should have the specific time range inside a "time" element', () => {
-            const timeTree = tdTree.subTree('time');
-            const expected = `${props.slot.start}/${props.slot.end}`;
+          it('has the specific time range inside a "time" element', () => {
+            const time = tableCell.find('time');
+            const expected = `${defaultProps.slot.start}/${defaultProps.slot.end}`;
 
-            expect(timeTree.props.dateTime).to.equal(expected);
+            expect(time.props().dateTime).to.equal(expected);
           });
         });
 
         describe('the third table cell', () => {
-          describe('when the slot is available', () => {
-            const tdTree = tdTrees[2];
-            const labelTrees = tdTree.everySubTree('Label');
+          const tableCell = tableCells.at(2);
+          const label = tableCell.find(Label);
 
-            it('should render a label', () => {
-              expect(labelTrees.length).to.equal(1);
-            });
+          it('contains a label with correct props', () => {
+            expect(label.length).to.equal(1);
+            expect(label.props().bsStyle).to.equal('success');
+          });
 
-            it('should give proper props to the label', () => {
-              expect(labelTrees[0].props.bsStyle).to.equal('success');
-            });
-
-            it('should display text "Vapaa"', () => {
-              const expected = 'Vapaa';
-
-              expect(labelTrees[0].props.children).to.equal(expected);
-            });
+          it('displays text "Vapaa"', () => {
+            expect(label.props().children).to.equal('Vapaa');
           });
         });
       });
     });
 
     describe('when the slot is reserved', () => {
-      const props = getProps({
+      const extraProps = {
         slot: Immutable(TimeSlotFixture.build({
           reserved: true,
           reservation: Reservation.build(),
         })),
-      });
-      const reservedTree = sd.shallowRender(<TimeSlot {...props} />);
-      const tdTree = reservedTree.everySubTree('td')[2];
-      const labelTrees = tdTree.everySubTree('Label');
+      };
+      const wrapper = getWrapper(extraProps);
 
-      it('should render a label', () => {
-        expect(labelTrees.length).to.equal(1);
-      });
+      it('renders a label with correct props', () => {
+        const label = wrapper.find(Label);
 
-      it('should give proper props to the label', () => {
-        expect(labelTrees[0].props.bsStyle).to.equal('danger');
+        expect(label.length).to.equal(1);
+        expect(label.props().bsStyle).to.equal('danger');
       });
 
-      it('should display text "Varattu"', () => {
-        const expected = 'Varattu';
+      it('displays text "Varattu"', () => {
+        const label = wrapper.find(Label);
 
-        expect(labelTrees[0].props.children).to.equal(expected);
+        expect(label.props().children).to.equal('Varattu');
       });
     });
   });

--- a/app/screens/resource/reservation-calendar/time-slots/TimeSlot.spec.js
+++ b/app/screens/resource/reservation-calendar/time-slots/TimeSlot.spec.js
@@ -9,7 +9,7 @@ import simple from 'simple-mock';
 import TimeSlotFixture from 'fixtures/TimeSlot';
 import Reservation from 'fixtures/Reservation';
 import Resource from 'fixtures/Resource';
-import TimeSlot from './TimeSlot';
+import TimeSlot, { getLabelData } from './TimeSlot';
 
 describe('screens/resource/reservation-calendar/time-slots/TimeSlot', () => {
   const defaultProps = {
@@ -27,6 +27,82 @@ describe('screens/resource/reservation-calendar/time-slots/TimeSlot', () => {
   function getWrapper(extraProps) {
     return shallow(<TimeSlot {...defaultProps} {...extraProps} />);
   }
+
+  describe('getLabelData', () => {
+    describe('when time is in the past', () => {
+      const isPast = true;
+
+      it('returns correct data if slot is being edited', () => {
+        const slot = { editing: true };
+        const labelData = getLabelData({ isPast, slot });
+        const expected = { bsStyle: 'default', text: 'Muokataan' };
+
+        expect(labelData).to.deep.equal(expected);
+      });
+
+      it('returns correct data if slot is reserved', () => {
+        const slot = { reserved: true };
+        const labelData = getLabelData({ isPast, slot });
+        const expected = { bsStyle: 'default', text: 'Varattu' };
+
+        expect(labelData).to.deep.equal(expected);
+      });
+
+      it('returns correct data if slot contains own reservation', () => {
+        const slot = { reserved: true };
+        const isOwnReservation = true;
+        const labelData = getLabelData({ isOwnReservation, isPast, slot });
+        const expected = { bsStyle: 'default', text: 'Oma varaus' };
+
+        expect(labelData).to.deep.equal(expected);
+      });
+
+      it('returns correct data if slot is not reserved', () => {
+        const slot = { reserved: false };
+        const labelData = getLabelData({ isPast, slot });
+        const expected = { bsStyle: 'default', text: 'Vapaa' };
+
+        expect(labelData).to.deep.equal(expected);
+      });
+    });
+
+    describe('when time is not in the past', () => {
+      const isPast = false;
+
+      it('returns correct data if slot is being edited', () => {
+        const slot = { editing: true };
+        const labelData = getLabelData({ isPast, slot });
+        const expected = { bsStyle: 'info', text: 'Muokataan' };
+
+        expect(labelData).to.deep.equal(expected);
+      });
+
+      it('returns correct data if slot is reserved', () => {
+        const slot = { reserved: true };
+        const labelData = getLabelData({ isPast, slot });
+        const expected = { bsStyle: 'danger', text: 'Varattu' };
+
+        expect(labelData).to.deep.equal(expected);
+      });
+
+      it('returns correct data if slot contains own reservation', () => {
+        const slot = { reserved: true };
+        const isOwnReservation = true;
+        const labelData = getLabelData({ isOwnReservation, isPast, slot });
+        const expected = { bsStyle: 'info', text: 'Oma varaus' };
+
+        expect(labelData).to.deep.equal(expected);
+      });
+
+      it('returns correct data if slot is not reserved', () => {
+        const slot = { reserved: false };
+        const labelData = getLabelData({ isPast, slot });
+        const expected = { bsStyle: 'success', text: 'Vapaa' };
+
+        expect(labelData).to.deep.equal(expected);
+      });
+    });
+  });
 
   describe('render', () => {
     describe('when the slot is not reserved', () => {

--- a/app/screens/resource/reservation-calendar/time-slots/TimeSlots.js
+++ b/app/screens/resource/reservation-calendar/time-slots/TimeSlots.js
@@ -62,6 +62,7 @@ class TimeSlots extends Component {
                 <th />
                 <th>Aika</th>
                 <th>Varaustilanne</th>
+                {!isAdmin && <th />}
                 {isAdmin && <th>Varaaja</th>}
                 {isAdmin && <th>Kommentit</th>}
                 {isAdmin && <th>Toiminnot</th>}

--- a/app/screens/resource/reservation-calendar/time-slots/TimeSlots.spec.js
+++ b/app/screens/resource/reservation-calendar/time-slots/TimeSlots.spec.js
@@ -1,121 +1,127 @@
 import { expect } from 'chai';
+import { shallow } from 'enzyme';
 import React from 'react';
+import Table from 'react-bootstrap/lib/Table';
 import Immutable from 'seamless-immutable';
 import simple from 'simple-mock';
-import sd from 'skin-deep';
 
 import Resource from 'fixtures/Resource';
 import TimeSlot from 'fixtures/TimeSlot';
 import TimeSlots from './TimeSlots';
+import TimeSlotComponent from './TimeSlot';
 
-describe('Component: reservation/TimeSlots', () => {
+describe('screens/resource/reservation-calendar/time-slots/TimeSlots', () => {
+  const defaultSlots = [
+    TimeSlot.build(),
+    TimeSlot.build(),
+  ];
+  const defaultProps = {
+    addNotification: simple.stub(),
+    isAdmin: false,
+    isEditing: false,
+    isFetching: false,
+    isLoggedIn: true,
+    isStaff: false,
+    onClick: simple.stub(),
+    resource: Resource.build(),
+    selected: [defaultSlots[0].asISOString],
+    slots: Immutable(defaultSlots),
+  };
+
+  function getWrapper(extraProps) {
+    return shallow(<TimeSlots {...defaultProps} {...extraProps} />);
+  }
+
   describe('with timeslots', () => {
-    const timeSlots = [
-      TimeSlot.build(),
-      TimeSlot.build(),
-    ];
-    const props = {
-      addNotification: simple.stub(),
-      isAdmin: false,
-      isEditing: false,
-      isFetching: false,
-      isLoggedIn: true,
-      isStaff: false,
-      onClick: simple.stub(),
-      resource: Resource.build(),
-      selected: [timeSlots[0].asISOString],
-      slots: Immutable(timeSlots),
-    };
-    let tree;
+    let wrapper;
 
     before(() => {
-      tree = sd.shallowRender(<TimeSlots {...props} />);
+      wrapper = getWrapper();
     });
 
-    it('should render a Table component', () => {
-      const tableTrees = tree.everySubTree('Table');
+    it('renders a Table component', () => {
+      const table = wrapper.find(Table);
 
-      expect(tableTrees.length).to.equal(1);
+      expect(table.length).to.equal(1);
     });
 
-    describe('rendering table headers', () => {
-      let thTrees;
+    describe('table headers', () => {
+      let tableHeaders;
 
       before(() => {
-        thTrees = tree.everySubTree('th');
+        tableHeaders = wrapper.find('th');
       });
 
-      it('should render 3 th elements', () => {
-        expect(thTrees.length).to.equal(3);
+      it('renders 4 th elements', () => {
+        expect(tableHeaders.length).to.equal(4);
       });
 
-      it('first th element should be empty', () => {
-        expect(thTrees[0].text()).to.equal('');
+      it('first th element is empty', () => {
+        expect(tableHeaders.at(0).text()).to.equal('');
       });
 
-      it('second th element should contain text "Aika"', () => {
-        expect(thTrees[1].text()).to.equal('Aika');
+      it('second th element contains text "Aika"', () => {
+        expect(tableHeaders.at(1).text()).to.equal('Aika');
       });
 
-      it('third th element should contain text "Varaustilanne"', () => {
-        expect(thTrees[2].text()).to.equal('Varaustilanne');
+      it('third th element contains text "Varaustilanne"', () => {
+        expect(tableHeaders.at(2).text()).to.equal('Varaustilanne');
+      });
+
+      it('fourth th element is empty', () => {
+        expect(tableHeaders.at(3).text()).to.equal('');
       });
     });
 
     describe('rendering individual time slots', () => {
-      let timeSlotTrees;
+      let timeSlots;
 
       before(() => {
-        timeSlotTrees = tree.everySubTree('TimeSlot');
+        timeSlots = wrapper.find(TimeSlotComponent);
       });
 
-      it('should render a TimeSlot for every time slot in props', () => {
-        expect(timeSlotTrees.length).to.equal(props.slots.length);
+      it('renders a TimeSlot component for every time slot in props', () => {
+        expect(timeSlots.length).to.equal(defaultProps.slots.length);
       });
 
-      it('should pass correct props to TimeSlots', () => {
-        timeSlotTrees.forEach((timeSlotTree, index) => {
-          expect(timeSlotTree.props.addNotification).to.equal(props.addNotification);
-          expect(timeSlotTree.props.isAdmin).to.equal(props.isAdmin);
-          expect(timeSlotTree.props.isEditing).to.equal(props.isEditing);
-          expect(timeSlotTree.props.isLoggedIn).to.equal(props.isLoggedIn);
-          expect(timeSlotTree.props.isStaff).to.equal(props.isStaff);
-          expect(timeSlotTree.props.onClick).to.equal(props.onClick);
-          expect(timeSlotTree.props.resource).to.equal(props.resource);
-          expect(timeSlotTree.props.slot).to.deep.equal(props.slots[index]);
+      it('passes correct props to TimeSlots', () => {
+        timeSlots.forEach((timeSlot, index) => {
+          expect(timeSlot.props().addNotification).to.equal(defaultProps.addNotification);
+          expect(timeSlot.props().isAdmin).to.equal(defaultProps.isAdmin);
+          expect(timeSlot.props().isEditing).to.equal(defaultProps.isEditing);
+          expect(timeSlot.props().isLoggedIn).to.equal(defaultProps.isLoggedIn);
+          expect(timeSlot.props().isStaff).to.equal(defaultProps.isStaff);
+          expect(timeSlot.props().onClick).to.equal(defaultProps.onClick);
+          expect(timeSlot.props().resource).to.equal(defaultProps.resource);
+          expect(timeSlot.props().slot).to.deep.equal(defaultProps.slots[index]);
         });
       });
 
-      it('should pass correct selected as a prop to TimeSlot', () => {
-        expect(timeSlotTrees[0].props.selected).to.equal(true);
-        expect(timeSlotTrees[1].props.selected).to.equal(false);
+      it('passes correct selected as a prop to TimeSlot', () => {
+        expect(timeSlots.at(0).props().selected).to.equal(true);
+        expect(timeSlots.at(1).props().selected).to.equal(false);
       });
     });
   });
 
   describe('without timeslots', () => {
-    const props = {
-      addNotification: simple.stub(),
-      isAdmin: false,
-      isEditing: false,
-      isFetching: false,
-      isLoggedIn: true,
-      isStaff: false,
-      onClick: simple.stub(),
-      resource: Resource.build(),
-      selected: [],
-      slots: [],
-    };
-    let tree;
+    const slots = [];
+    let wrapper;
 
     before(() => {
-      tree = sd.shallowRender(<TimeSlots {...props} />);
+      wrapper = getWrapper({ slots });
     });
 
-    it('should render a message telling the resource is not available for reservation', () => {
+    it('renders a message telling the resource is not available for reservation', () => {
       const expected = 'Tila ei ole varattavissa tänä päivänä.';
 
-      expect(tree.textIn('p')).to.equal(expected);
+      expect(wrapper.find('p').text()).to.equal(expected);
+    });
+
+    it('does not render a Table component', () => {
+      const table = wrapper.find(Table);
+
+      expect(table.length).to.equal(0);
     });
   });
 });

--- a/app/screens/resource/reservation-calendar/time-slots/time-slots.less
+++ b/app/screens/resource/reservation-calendar/time-slots/time-slots.less
@@ -38,6 +38,11 @@
       }
     }
 
+    .controls-cell {
+      width: 140px;
+      text-align: right;
+    }
+
     // Reserved styles
     // ---------------
     &.reserved {
@@ -105,10 +110,6 @@
 
       .status-cell {
         width: 80px;
-      }
-
-      .controls-cell {
-        width: 140px;
       }
     }
   }

--- a/app/screens/resource/reservation-calendar/time-slots/time-slots.less
+++ b/app/screens/resource/reservation-calendar/time-slots/time-slots.less
@@ -41,7 +41,7 @@
     // Reserved styles
     // ---------------
     &.reserved {
-      &.is-admin {
+      &.is-admin, &.own-reservation {
         background-color: @gray-lighter;
       }
 


### PR DESCRIPTION
This PR:
- Makes users' own reservations distinguishable in reservation calendar.
- Adds reservation controls to user's own reservations to reservation calendar.
- Adds basic styling but probably more work on responsive styles still needs to be done later.

Closes #438.