### PR TITLE
Remove should's from test descriptions

### DIFF
--- a/app/pages/admin-resources/AdminResourcesPage.spec.js
+++ b/app/pages/admin-resources/AdminResourcesPage.spec.js
@@ -46,7 +46,7 @@ describe('pages/admin-resources/AdminResourcesPage', () => {
     describe('when user is an admin', () => {
       const wrapper = getWrapper({ isAdmin: true });
 
-      it('should display "Omat tilat" -title inside h1 tags', () => {
+      it('displays "Omat tilat" -title inside h1 tags', () => {
         const h1 = wrapper.find('h1');
         expect(h1.text()).to.equal('Omat tilat');
       });

--- a/app/pages/admin-resources/resources-table/ResourcesTable.spec.js
+++ b/app/pages/admin-resources/resources-table/ResourcesTable.spec.js
@@ -130,7 +130,7 @@ describe('pages/admin-resources/resources-table/ResourcesTable', () => {
         });
       });
 
-      it('should display the emptyMessage', () => {
+      it('displays the emptyMessage', () => {
         expect(wrapper.is('p')).to.be.true;
         expect(wrapper.text()).to.equal('No resources found');
       });
@@ -143,7 +143,7 @@ describe('pages/admin-resources/resources-table/ResourcesTable', () => {
         wrapper = getWrapper({ resources: [] });
       });
 
-      it('should render a message telling no resources were found', () => {
+      it('renders a message telling no resources were found', () => {
         const expected = 'Et ole lisännyt vielä yhtään tilaa itsellesi.';
         expect(wrapper.is('p')).to.be.true;
         expect(wrapper.text()).to.equal(expected);

--- a/app/pages/home/intro/ShowResourcesLink.spec.js
+++ b/app/pages/home/intro/ShowResourcesLink.spec.js
@@ -14,7 +14,7 @@ describe('pages/home/intro/ShowResourcesLink', () => {
     expect(link.length).to.equal(1);
   });
 
-  it('the Link should have correct url', () => {
+  it('the Link has correct url', () => {
     const link = wrapper.find(Link);
     const expectedUrl = getSearchPageUrl({ purpose: 'all' });
     expect(link.props().to).to.equal(expectedUrl);

--- a/app/pages/home/purpose-list/purposeListSelector.spec.js
+++ b/app/pages/home/purpose-list/purposeListSelector.spec.js
@@ -8,7 +8,7 @@ describe('pages/home/purpose-list/purposeListSelector', () => {
   const props = getDefaultRouterProps();
   const selected = purposeListSelector(state, props);
 
-  it('should return isFetchingPurposes', () => {
+  it('returns isFetchingPurposes', () => {
     expect(selected.isFetchingPurposes).to.exist;
   });
 

--- a/app/pages/resource/reservation-calendar/ReservationCalendarControls.spec.js
+++ b/app/pages/resource/reservation-calendar/ReservationCalendarControls.spec.js
@@ -27,19 +27,19 @@ describe('pages/resource/reservation-calendar/ReservationCalendarControls', () =
     const tree = sd.shallowRender(<ReservationCalendarControls {...props} />);
     const instance = tree.getMountedInstance();
 
-    it('should render one button', () => {
+    it('renders one button', () => {
       const buttonTrees = tree.everySubTree('Button');
 
       expect(buttonTrees.length).to.equal(1);
     });
 
-    it('should pass correct props to the button', () => {
+    it('passes correct props to the button', () => {
       const actualProps = tree.subTree('Button').props;
 
       expect(actualProps.onClick).to.equal(instance.handleMainClick);
     });
 
-    it('the button should have text "Varaa"', () => {
+    it('the button has text "Varaa"', () => {
       expect(tree.subTree('Button').props.children).to.equal('Varaa');
     });
   });
@@ -52,18 +52,18 @@ describe('pages/resource/reservation-calendar/ReservationCalendarControls', () =
     const instance = tree.getMountedInstance();
     const buttonTrees = tree.everySubTree('Button');
 
-    it('should render two buttons', () => {
+    it('renders two buttons', () => {
       expect(buttonTrees.length).to.equal(2);
     });
 
     describe('the first button', () => {
       const buttonTree = buttonTrees[0];
 
-      it('should be a confirm edit button', () => {
+      it('is a confirm edit button', () => {
         expect(buttonTree.props.children).to.equal('Vahvista muutokset');
       });
 
-      it('should have correct props', () => {
+      it('has correct props', () => {
         expect(buttonTree.props.onClick).to.equal(instance.handleMainClick);
       });
     });
@@ -71,11 +71,11 @@ describe('pages/resource/reservation-calendar/ReservationCalendarControls', () =
     describe('the second button', () => {
       const buttonTree = buttonTrees[1];
 
-      it('should be a cancel button', () => {
+      it('is a cancel button', () => {
         expect(buttonTree.props.children).to.equal('Takaisin');
       });
 
-      it('should have correct props', () => {
+      it('has correct props', () => {
         expect(buttonTree.props.onClick).to.equal(props.onCancel);
       });
     });

--- a/app/pages/resource/reservation-confirmation/ConfirmReservationModal.spec.js
+++ b/app/pages/resource/reservation-confirmation/ConfirmReservationModal.spec.js
@@ -45,7 +45,7 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
       commentInput: { getValue: simple.stub() },
     };
 
-    it('should render a Modal component', () => {
+    it('renders a Modal component', () => {
       const modalTrees = tree.everySubTree('Modal');
 
       expect(modalTrees.length).to.equal(1);
@@ -54,21 +54,21 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
     describe('Modal header', () => {
       const modalHeaderTrees = tree.everySubTree('ModalHeader');
 
-      it('should render a ModalHeader component', () => {
+      it('renders a ModalHeader component', () => {
         expect(modalHeaderTrees.length).to.equal(1);
       });
 
-      it('should contain a close button', () => {
+      it('contains a close button', () => {
         expect(modalHeaderTrees[0].props.closeButton).to.equal(true);
       });
 
-      it('should render a ModalTitle component', () => {
+      it('renders a ModalTitle component', () => {
         const modalTitleTrees = tree.everySubTree('ModalTitle');
 
         expect(modalTitleTrees.length).to.equal(1);
       });
 
-      it('the ModalTitle should display text "Varauksen vahvistus"', () => {
+      it('the ModalTitle displays text "Varauksen vahvistus"', () => {
         const modalTitleTree = tree.subTree('ModalTitle');
 
         expect(modalTitleTree.props.children).to.equal('Varauksen vahvistus');
@@ -78,22 +78,22 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
     describe('Modal body', () => {
       const modalBodyTrees = tree.everySubTree('ModalBody');
 
-      it('should render a ModalBody component', () => {
+      it('renders a ModalBody component', () => {
         expect(modalBodyTrees.length).to.equal(1);
       });
 
-      it('should render a help text asking for confirmation', () => {
+      it('renders a help text asking for confirmation', () => {
         const textTree = modalBodyTrees[0].subTree('p');
         const expected = 'Oletko varma että haluat tehdä varaukset ajoille:';
         expect(textTree.text()).to.equal(expected);
       });
 
-      it('should render a CompactReservationList component', () => {
+      it('renders a CompactReservationList component', () => {
         const list = modalBodyTrees[0].everySubTree('CompactReservationList');
         expect(list.length).to.equal(1);
       });
 
-      it('should pass correct props to CompactReservationList component', () => {
+      it('passes correct props to CompactReservationList component', () => {
         const list = modalBodyTrees[0].subTree('CompactReservationList');
         expect(list.props.reservations).to.deep.equal(props.selectedReservations);
       });
@@ -115,7 +115,7 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
       commentInput: { getValue: simple.stub() },
     };
 
-    it('should render a Modal component', () => {
+    it('renders a Modal component', () => {
       const modalTrees = tree.everySubTree('Modal');
 
       expect(modalTrees.length).to.equal(1);
@@ -124,21 +124,21 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
     describe('Modal header', () => {
       const modalHeaderTrees = tree.everySubTree('ModalHeader');
 
-      it('should render a ModalHeader component', () => {
+      it('renders a ModalHeader component', () => {
         expect(modalHeaderTrees.length).to.equal(1);
       });
 
-      it('should contain a close button', () => {
+      it('contains a close button', () => {
         expect(modalHeaderTrees[0].props.closeButton).to.equal(true);
       });
 
-      it('should render a ModalTitle component', () => {
+      it('renders a ModalTitle component', () => {
         const modalTitleTrees = tree.everySubTree('ModalTitle');
 
         expect(modalTitleTrees.length).to.equal(1);
       });
 
-      it('the ModalTitle should display text "Alustava varaus"', () => {
+      it('the ModalTitle displays text "Alustava varaus"', () => {
         const modalTitleTree = tree.subTree('ModalTitle');
 
         expect(modalTitleTree.props.children).to.equal('Alustava varaus');
@@ -148,22 +148,22 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
     describe('Modal body', () => {
       const modalBodyTrees = tree.everySubTree('ModalBody');
 
-      it('should render a ModalBody component', () => {
+      it('renders a ModalBody component', () => {
         expect(modalBodyTrees.length).to.equal(1);
       });
 
-      it('should render a help text asking for confirmation', () => {
+      it('renders a help text asking for confirmation', () => {
         const textTree = modalBodyTrees[0].subTree('p');
         const expected = 'Olet tekemässä alustavaa varausta ajoille:';
         expect(textTree.text()).to.equal(expected);
       });
 
-      it('should render a CompactReservationList component', () => {
+      it('renders a CompactReservationList component', () => {
         const list = modalBodyTrees[0].everySubTree('CompactReservationList');
         expect(list.length).to.equal(1);
       });
 
-      it('should pass correct props to CompactReservationList component', () => {
+      it('passes correct props to CompactReservationList component', () => {
         const list = modalBodyTrees[0].subTree('CompactReservationList');
         expect(list.props.reservations).to.deep.equal(props.selectedReservations);
       });
@@ -186,7 +186,7 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
       commentInput: { getValue: simple.stub() },
     };
 
-    it('should render a Modal component', () => {
+    it('renders a Modal component', () => {
       const modalTrees = tree.everySubTree('Modal');
 
       expect(modalTrees.length).to.equal(1);
@@ -195,21 +195,21 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
     describe('Modal header', () => {
       const modalHeaderTrees = tree.everySubTree('ModalHeader');
 
-      it('should render a ModalHeader component', () => {
+      it('renders a ModalHeader component', () => {
         expect(modalHeaderTrees.length).to.equal(1);
       });
 
-      it('should contain a close button', () => {
+      it('contains a close button', () => {
         expect(modalHeaderTrees[0].props.closeButton).to.equal(true);
       });
 
-      it('should render a ModalTitle component', () => {
+      it('renders a ModalTitle component', () => {
         const modalTitleTrees = tree.everySubTree('ModalTitle');
 
         expect(modalTitleTrees.length).to.equal(1);
       });
 
-      it('the ModalTitle should display text "Muutosten vahvistus"', () => {
+      it('the ModalTitle displays text "Muutosten vahvistus"', () => {
         const modalTitleTree = tree.subTree('ModalTitle');
 
         expect(modalTitleTree.props.children).to.equal('Muutosten vahvistus');
@@ -219,21 +219,21 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
     describe('Modal body', () => {
       const modalBodyTrees = tree.everySubTree('ModalBody');
 
-      it('should render a ModalBody component', () => {
+      it('renders a ModalBody component', () => {
         expect(modalBodyTrees.length).to.equal(1);
       });
 
-      it('should render two lists', () => {
+      it('renders two lists', () => {
         const lists = modalBodyTrees[0].everySubTree('CompactReservationList');
         expect(lists.length).to.equal(2);
       });
 
-      it('the first list should contain reservations that are edited', () => {
+      it('the first list contains reservations that are edited', () => {
         const list = modalBodyTrees[0].everySubTree('CompactReservationList')[0];
         expect(list.props.reservations).to.deep.equal(props.reservationsToEdit);
       });
 
-      it('the second list should contain reservations that are selected', () => {
+      it('the second list contains reservations that are selected', () => {
         const list = modalBodyTrees[0].everySubTree('CompactReservationList')[1];
         expect(list.props.reservations).to.deep.equal(props.selectedReservations);
       });
@@ -259,15 +259,15 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
         const form = getForm(needManualConfirmation, isAdmin, isStaff);
         const formFields = form.props().fields;
 
-        it('form fields should include staffEvent', () => {
+        it('form fields include staffEvent', () => {
           expect(formFields).to.contain('staffEvent');
         });
 
-        it('form fields should include comments', () => {
+        it('form fields include comments', () => {
           expect(formFields).to.contain('comments');
         });
 
-        it('form fields should include RESERVATION_FORM_FIELDS', () => {
+        it('form fields include RESERVATION_FORM_FIELDS', () => {
           forEach(constants.RESERVATION_FORM_FIELDS, (field) => {
             expect(formFields).to.contain(field);
           });
@@ -280,15 +280,15 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
         const form = getForm(needManualConfirmation, isAdmin, isStaff);
         const formFields = form.props().fields;
 
-        it('form fields should not include staffEvent', () => {
+        it('form fields do not include staffEvent', () => {
           expect(formFields).to.not.contain('staffEvent');
         });
 
-        it('form fields should include comments', () => {
+        it('form fields include comments', () => {
           expect(formFields).to.contain('comments');
         });
 
-        it('form fields should include RESERVATION_FORM_FIELDS', () => {
+        it('form fields include RESERVATION_FORM_FIELDS', () => {
           forEach(constants.RESERVATION_FORM_FIELDS, (field) => {
             expect(formFields).to.contain(field);
           });
@@ -301,15 +301,15 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
         const form = getForm(needManualConfirmation, isAdmin, isStaff);
         const formFields = form.props().fields;
 
-        it('form fields should not include staffEvent', () => {
+        it('form fields do not include staffEvent', () => {
           expect(formFields).to.not.contain('staffEvent');
         });
 
-        it('form fields should not include comments', () => {
+        it('form fields do not include comments', () => {
           expect(formFields).to.not.contain('comments');
         });
 
-        it('form fields should include RESERVATION_FORM_FIELDS', () => {
+        it('form fields include RESERVATION_FORM_FIELDS', () => {
           forEach(constants.RESERVATION_FORM_FIELDS, (field) => {
             expect(formFields).to.contain(field);
           });
@@ -324,15 +324,15 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
         const form = getForm(needManualConfirmation, isAdmin);
         const formFields = form.props().fields;
 
-        it('form fields should not include staffEvent', () => {
+        it('form fields do not include staffEvent', () => {
           expect(formFields).to.not.contain('staffEvent');
         });
 
-        it('form fields should include comments', () => {
+        it('form fields include comments', () => {
           expect(formFields).to.contain('comments');
         });
 
-        it('form fields should not include RESERVATION_FORM_FIELDS', () => {
+        it('form fields do not include RESERVATION_FORM_FIELDS', () => {
           forEach(constants.RESERVATION_FORM_FIELDS, (field) => {
             expect(formFields).to.not.contain(field);
           });
@@ -344,15 +344,15 @@ describe('pages/resource/reservation-confirmation/ConfirmReservationModal', () =
         const form = getForm(needManualConfirmation, isAdmin);
         const formFields = form.props().fields;
 
-        it('form fields should not include staffEvent', () => {
+        it('form fields do not include staffEvent', () => {
           expect(formFields).to.not.contain('staffEvent');
         });
 
-        it('form fields should not include comments', () => {
+        it('form fields do not include comments', () => {
           expect(formFields).to.not.contain('comments');
         });
 
-        it('form fields should not include RESERVATION_FORM_FIELDS', () => {
+        it('form fields do not include RESERVATION_FORM_FIELDS', () => {
           forEach(constants.RESERVATION_FORM_FIELDS, (field) => {
             expect(formFields).to.not.contain(field);
           });

--- a/app/pages/resource/reservation-confirmation/ReservationForm.spec.js
+++ b/app/pages/resource/reservation-confirmation/ReservationForm.spec.js
@@ -134,7 +134,7 @@ describe('pages/resource/reservation-confirmation/ReservationForm', () => {
         });
 
         describe('required fields', () => {
-          it('should display an asterisk beside a required field label', () => {
+          it('displays an asterisk beside a required field label', () => {
             const fieldName = constants.RESERVATION_FORM_FIELDS[0];
             const props = {
               fields: { [fieldName]: { name: fieldName } },

--- a/app/pages/search/controls/searchControlsSelector.spec.js
+++ b/app/pages/search/controls/searchControlsSelector.spec.js
@@ -8,19 +8,19 @@ describe('Selector: searchControlsSelector', () => {
   const props = getDefaultRouterProps();
   const selected = searchControlsSelector(state, props);
 
-  it('should return filters', () => {
+  it('returns filters', () => {
     expect(selected.filters).to.exist;
   });
 
-  it('should return isFetchingPurposes', () => {
+  it('returns isFetchingPurposes', () => {
     expect(selected.isFetchingPurposes).to.exist;
   });
 
-  it('should return purposeOptions', () => {
+  it('returns purposeOptions', () => {
     expect(selected.purposeOptions).to.exist;
   });
 
-  it('should return urlSearchFilters', () => {
+  it('returns urlSearchFilters', () => {
     expect(selected.urlSearchFilters).to.exist;
   });
 });

--- a/app/pages/user-reservations/UserReservationsPage.spec.js
+++ b/app/pages/user-reservations/UserReservationsPage.spec.js
@@ -35,20 +35,20 @@ describe('pages/user-reservations/UserReservationsPage', () => {
     describe('when user is not admin', () => {
       const wrapper = getWrapper({ isAdmin: false });
 
-      it('should display "Omat varaukset" -title inside h1 tags', () => {
+      it('displays "Omat varaukset" -title inside h1 tags', () => {
         const h1 = wrapper.find('h1');
 
         expect(h1.text()).to.equal('Omat varaukset');
       });
 
-      it('should render ReservationList with all user reservations', () => {
+      it('renders ReservationList with all user reservations', () => {
         const reservationList = wrapper.find(ReservationList);
 
         expect(reservationList.length).to.equal(1);
         expect(reservationList.props().filter).to.not.exist;
       });
 
-      it('should not render AdminReservationFilters', () => {
+      it('does not render AdminReservationFilters', () => {
         const adminReservationFilters = wrapper.find(AdminReservationFilters);
         expect(adminReservationFilters.length).to.equal(0);
       });
@@ -60,15 +60,15 @@ describe('pages/user-reservations/UserReservationsPage', () => {
       describe('headers', () => {
         const headers = wrapper.find('h1');
 
-        it('should render two headers', () => {
+        it('renders two headers', () => {
           expect(headers.length).to.equal(2);
         });
 
-        it('the first header should display "Alustavat varaukset"', () => {
+        it('the first header displays "Alustavat varaukset"', () => {
           expect(headers.at(0).text()).to.equal('Alustavat varaukset');
         });
 
-        it('the second header should display "Tavalliset varaukset"', () => {
+        it('the second header displays "Tavalliset varaukset"', () => {
           expect(headers.at(1).text()).to.equal('Tavalliset varaukset');
         });
       });
@@ -76,11 +76,11 @@ describe('pages/user-reservations/UserReservationsPage', () => {
       describe('AdminReservationFilters', () => {
         const adminReservationFilters = wrapper.find(AdminReservationFilters);
 
-        it('should render AdminReservationFilters', () => {
+        it('renders AdminReservationFilters', () => {
           expect(adminReservationFilters.length).to.equal(1);
         });
 
-        it('should pass correct props to AdminReservationFilters', () => {
+        it('passes correct props to AdminReservationFilters', () => {
           const actualProps = adminReservationFilters.props();
           expect(actualProps.filters).to.deep.equal(defaultProps.adminReservationFilters);
           expect(typeof actualProps.onFiltersChange).to.equal('function');
@@ -90,18 +90,18 @@ describe('pages/user-reservations/UserReservationsPage', () => {
       describe('reservation lists', () => {
         const lists = wrapper.find(ReservationList);
 
-        it('should render two reservation lists', () => {
+        it('renders two reservation lists', () => {
           expect(lists.length).to.equal(2);
         });
 
         describe('the first list', () => {
           const list = lists.at(0);
 
-          it('should only contain filtered preliminary reservations', () => {
+          it('contains only filtered preliminary reservations', () => {
             expect(list.props().filter).to.equal(defaultProps.adminReservationFilters.state);
           });
 
-          it('should be in correct loading state', () => {
+          it('is in correct loading state', () => {
             expect(list.props().loading).to.equal(defaultProps.reservationsFetchCount < 2);
           });
         });
@@ -109,11 +109,11 @@ describe('pages/user-reservations/UserReservationsPage', () => {
         describe('the second list', () => {
           const list = lists.at(1);
 
-          it('the second list should only contain regular reservations', () => {
+          it('the second list contains only regular reservations', () => {
             expect(list.props().filter).to.equal('regular');
           });
 
-          it('should be in correct loading state', () => {
+          it('is in correct loading state', () => {
             expect(list.props().loading).to.equal(defaultProps.reservationsFetchCount < 1);
           });
         });
@@ -130,15 +130,15 @@ describe('pages/user-reservations/UserReservationsPage', () => {
         getWrapper({ isAdmin: false }).instance().componentDidMount();
       });
 
-      it('should fetch resources', () => {
+      it('fetches resources', () => {
         expect(fetchResources.callCount).to.equal(1);
       });
 
-      it('should fetch units', () => {
+      it('fetches units', () => {
         expect(fetchUnits.callCount).to.equal(1);
       });
 
-      it('should only fetch user\'s own reservations', () => {
+      it('fetches only user\'s own reservations', () => {
         expect(fetchReservations.callCount).to.equal(1);
         expect(fetchReservations.lastCall.args[0].isOwn).to.equal(true);
       });
@@ -152,23 +152,23 @@ describe('pages/user-reservations/UserReservationsPage', () => {
         getWrapper({ isAdmin: true }).instance().componentDidMount();
       });
 
-      it('should fetch resources', () => {
+      it('fetches resources', () => {
         expect(fetchResources.callCount).to.equal(1);
       });
 
-      it('should fetch units', () => {
+      it('fetches units', () => {
         expect(fetchUnits.callCount).to.equal(1);
       });
 
-      it('should fetch two batches of reservations', () => {
+      it('fetches two batches of reservations', () => {
         expect(fetchReservations.callCount).to.equal(2);
       });
 
-      it('should fetch reservations admin can approve', () => {
+      it('fetches reservations admin can approve', () => {
         expect(fetchReservations.calls[0].args[0].canApprove).to.equal(true);
       });
 
-      it('should fetch admin\'s own reservations', () => {
+      it('fetches admin\'s own reservations', () => {
         expect(fetchReservations.calls[1].args[0].isOwn).to.equal(true);
       });
     });
@@ -183,7 +183,7 @@ describe('pages/user-reservations/UserReservationsPage', () => {
     });
 
     describe('if user is not an admin', () => {
-      it('should not fetch reservations', () => {
+      it('does not fetch reservations', () => {
         const nextProps = Object.assign({}, defaultProps, { isAdmin: false });
         instance.componentWillReceiveProps(nextProps);
         expect(fetchReservations.callCount).to.equal(0);
@@ -191,19 +191,19 @@ describe('pages/user-reservations/UserReservationsPage', () => {
     });
 
     describe('if user is an admin', () => {
-      it('should fetch reservations', () => {
+      it('fetches reservations', () => {
         const nextProps = Object.assign({}, defaultProps, { isAdmin: true });
         instance.componentWillReceiveProps(nextProps);
         expect(fetchReservations.callCount).to.equal(1);
       });
 
-      it('should fetch reservations admin can approve', () => {
+      it('fetches reservations admin can approve', () => {
         const nextProps = Object.assign({}, defaultProps, { isAdmin: true });
         instance.componentWillReceiveProps(nextProps);
         expect(fetchReservations.lastCall.args[0].canApprove).to.equal(true);
       });
 
-      it('should not fetch admin reservations twice', () => {
+      it('does not fetch admin reservations twice', () => {
         const nextProps = Object.assign({}, defaultProps, { isAdmin: true });
         instance.componentWillReceiveProps(nextProps);
         instance.componentWillReceiveProps(nextProps);
@@ -224,12 +224,12 @@ describe('pages/user-reservations/UserReservationsPage', () => {
         instance.handleFiltersChange(filters);
       });
 
-      it('should call changeAdminReservationFilters with correct filters', () => {
+      it('calls changeAdminReservationFilters with correct filters', () => {
         expect(changeAdminReservationFilters.callCount).to.equal(1);
         expect(changeAdminReservationFilters.lastCall.args[0]).to.deep.equal(filters);
       });
 
-      it('should call fetchReservations without any filters', () => {
+      it('calls fetchReservations without any filters', () => {
         expect(fetchReservations.callCount).to.equal(1);
         const expectedArgs = { canApprove: true };
         expect(fetchReservations.lastCall.args[0]).to.deep.equal(expectedArgs);
@@ -245,12 +245,12 @@ describe('pages/user-reservations/UserReservationsPage', () => {
         instance.handleFiltersChange(filters);
       });
 
-      it('should call changeAdminReservationFilters with correct filters', () => {
+      it('calls changeAdminReservationFilters with correct filters', () => {
         expect(changeAdminReservationFilters.callCount).to.equal(1);
         expect(changeAdminReservationFilters.lastCall.args[0]).to.deep.equal(filters);
       });
 
-      it('should call fetchReservations with correct state filter', () => {
+      it('calls fetchReservations with correct state filter', () => {
         expect(fetchReservations.callCount).to.equal(1);
         const expectedArgs = Object.assign({}, { canApprove: true }, filters);
         expect(fetchReservations.lastCall.args[0]).to.deep.equal(expectedArgs);

--- a/app/pages/user-reservations/reservation-list/ReservationListContainer.spec.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListContainer.spec.js
@@ -46,7 +46,7 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
       tree = sd.shallowRender(<ReservationListContainer {...props} />);
     });
 
-    it('should render a ul element', () => {
+    it('renders a ul element', () => {
       const ulTree = tree.subTree('ul');
 
       expect(ulTree).to.be.ok;
@@ -59,12 +59,12 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
         reservationListItemTrees = tree.everySubTree('ReservationListItem');
       });
 
-      it('should render a ReservationListItem for every reservation in props', () => {
+      it('renders a ReservationListItem for every reservation in props', () => {
         expect(reservationListItemTrees.length).to.equal(props.reservations.length);
       });
 
       describe('passing correct props', () => {
-        it('should pass isAdmin, isStaff and reservation', () => {
+        it('passes isAdmin, isStaff and reservation', () => {
           reservationListItemTrees.forEach((reservationTree, index) => {
             const actualProps = reservationTree.props;
 
@@ -74,19 +74,19 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
           });
         });
 
-        it('should pass resource corresponding to reservation.resource', () => {
+        it('passes resource corresponding to reservation.resource', () => {
           expect(reservationListItemTrees[0].props.resource).to.deep.equal(resource);
         });
 
-        it('should pass empty object as resource if resource is unfetched', () => {
+        it('passes empty object as resource if resource is unfetched', () => {
           expect(reservationListItemTrees[1].props.resource).to.deep.equal({});
         });
 
-        it('should pass unit corresponding to resource.unit', () => {
+        it('passes unit corresponding to resource.unit', () => {
           expect(reservationListItemTrees[0].props.unit).to.deep.equal(unit);
         });
 
-        it('should pass empty object as unit if unit or resource is unfetched', () => {
+        it('passes empty object as unit if unit or resource is unfetched', () => {
           expect(reservationListItemTrees[1].props.unit).to.deep.equal({});
         });
       });
@@ -101,7 +101,7 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
       });
       const tree = sd.shallowRender(<ReservationListContainer {...props} />);
 
-      it('should display the emptyMessage', () => {
+      it('displays the emptyMessage', () => {
         expect(tree.textIn('p')).to.equal(props.emptyMessage);
       });
     });
@@ -112,7 +112,7 @@ describe('pages/user-reservations/reservation-list/ReservationListContainer', ()
       });
       const tree = sd.shallowRender(<ReservationListContainer {...props} />);
 
-      it('should render a message telling no reservations were found', () => {
+      it('renders a message telling no reservations were found', () => {
         const expected = 'Sinulla ei vielä ole yhtään varausta.';
 
         expect(tree.textIn('p')).to.equal(expected);

--- a/app/pages/user-reservations/reservation-list/ReservationListItem.spec.js
+++ b/app/pages/user-reservations/reservation-list/ReservationListItem.spec.js
@@ -30,11 +30,11 @@ describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
   });
 
   describe('rendering', () => {
-    it('should render a li element', () => {
+    it('renders a li element', () => {
       expect(component.is('li')).to.be.true;
     });
 
-    it('should display an image with correct props', () => {
+    it('displays an image with correct props', () => {
       const image = component.find('img');
 
       expect(image).to.have.length(1);
@@ -42,26 +42,26 @@ describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
       expect(image.props().src).to.contain(props.resource.images[0].url);
     });
 
-    it('should contain a link to resources page', () => {
+    it('contains a link to resources page', () => {
       const expectedUrl = getResourcePageUrl(props.resource);
       const resourceLink = component.find({ to: expectedUrl });
 
       expect(resourceLink.length > 0).to.be.true;
     });
 
-    it('should display the name of the resource', () => {
+    it('displays the name of the resource', () => {
       const expected = props.resource.name.fi;
 
       expect(component.find('h4').text()).to.contain(expected);
     });
 
-    it('should display the name of the given unit in props', () => {
+    it('displays the name of the given unit in props', () => {
       const expected = props.unit.name.fi;
 
       expect(component.find('h4').text()).to.contain(expected);
     });
 
-    it('should contain a Link to resource page with correct time', () => {
+    it('contains a Link to resource page with correct time', () => {
       const expectedUrl = getResourcePageUrl(
         props.resource,
         props.reservation.begin,
@@ -73,7 +73,7 @@ describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
       expect(resourcePageLinkWithTime.length).to.equal(1);
     });
 
-    it('should contain two TimeRange components with correct begin and end times', () => {
+    it('contains two TimeRange components with correct begin and end times', () => {
       const timeRange = component.find(TimeRange);
 
       expect(timeRange).to.have.length(2);
@@ -83,12 +83,12 @@ describe('pages/user-reservations/reservation-list/ReservationListItem', () => {
       expect(timeRange.at(1).props().end).to.equal(props.reservation.end);
     });
 
-    it('should render ReservationControls component', () => {
+    it('renders ReservationControls component', () => {
       const reservationControls = component.find(ReservationControls);
       expect(reservationControls).to.have.length(1);
     });
 
-    it('should pass correct props to ReservationControls component', () => {
+    it('passes correct props to ReservationControls component', () => {
       const actualProps = component.find(ReservationControls).props();
 
       expect(actualProps.isAdmin).to.equal(false);

--- a/app/reducers/__tests__/activeRequestsReducer.spec.js
+++ b/app/reducers/__tests__/activeRequestsReducer.spec.js
@@ -9,7 +9,7 @@ describe('Reducer: activeRequestsReducer', () => {
   describe('initial state', () => {
     const initialState = activeRequestsReducer(undefined, {});
 
-    it('should be an empty object', () => {
+    it('is an empty object', () => {
       expect(initialState).to.deep.equal({});
     });
   });
@@ -28,7 +28,7 @@ describe('Reducer: activeRequestsReducer', () => {
       });
 
       describe('if activeRequests already contains the action', () => {
-        it('should increase the count of the action by one', () => {
+        it('increases the count of the action by one', () => {
           const initialState = Immutable(
             { SOME_REQUEST: 2 }
           );
@@ -40,7 +40,7 @@ describe('Reducer: activeRequestsReducer', () => {
           expect(nextState).to.deep.equal(expected);
         });
 
-        it('should not affect the existing activeRequests', () => {
+        it('does not affect the existing activeRequests', () => {
           const initialState = Immutable(
             { SOME_REQUEST: 2, OTHER_REQUEST: 1 }
           );
@@ -54,7 +54,7 @@ describe('Reducer: activeRequestsReducer', () => {
       });
 
       describe('if activeRequests does not already contain the action', () => {
-        it('should add the action to activeRequests with count 1', () => {
+        it('adds the action to activeRequests with count 1', () => {
           const initialState = Immutable({});
           const nextState = activeRequestsReducer(initialState, action);
           const expected = Immutable(
@@ -64,7 +64,7 @@ describe('Reducer: activeRequestsReducer', () => {
           expect(nextState).to.deep.equal(expected);
         });
 
-        it('should not affect the existing activeRequests', () => {
+        it('does not affect the existing activeRequests', () => {
           const initialState = Immutable(
             { OTHER_REQUEST: 1 }
           );
@@ -87,7 +87,7 @@ describe('Reducer: activeRequestsReducer', () => {
             type: 'SOME_REQUEST',
           });
 
-          it('should decrease the count of the action by one', () => {
+          it('decreases the count of the action by one', () => {
             const initialState = Immutable(
               { SOME_REQUEST: 2 }
             );
@@ -99,7 +99,7 @@ describe('Reducer: activeRequestsReducer', () => {
             expect(nextState).to.deep.equal(expected);
           });
 
-          it('should not affect the existing activeRequests', () => {
+          it('does not affect the existing activeRequests', () => {
             const initialState = Immutable(
               { SOME_REQUEST: 2, OTHER_REQUEST: 1 }
             );
@@ -118,7 +118,7 @@ describe('Reducer: activeRequestsReducer', () => {
             type: 'SOME_REQUEST',
           });
 
-          it('should set the count of the action to 0', () => {
+          it('sets the count of the action to 0', () => {
             const initialState = Immutable(
               { SOME_REQUEST: 2 }
             );
@@ -130,7 +130,7 @@ describe('Reducer: activeRequestsReducer', () => {
             expect(nextState).to.deep.equal(expected);
           });
 
-          it('should not affect the existing activeRequests', () => {
+          it('does not affect the existing activeRequests', () => {
             const initialState = Immutable(
               { SOME_REQUEST: 2, OTHER_REQUEST: 1 }
             );
@@ -150,7 +150,7 @@ describe('Reducer: activeRequestsReducer', () => {
           type: 'SOME_REQUEST',
         });
 
-        it('should add the action to activeRequests with count 0', () => {
+        it('adds the action to activeRequests with count 0', () => {
           const initialState = Immutable({});
           const nextState = activeRequestsReducer(initialState, action);
           const expected = Immutable(
@@ -160,7 +160,7 @@ describe('Reducer: activeRequestsReducer', () => {
           expect(nextState).to.deep.equal(expected);
         });
 
-        it('should not affect the existing activeRequests', () => {
+        it('does not affect the existing activeRequests', () => {
           const initialState = Immutable(
             { OTHER_REQUEST: 1 }
           );

--- a/app/reducers/__tests__/adminResourcesPageReducer.spec.js
+++ b/app/reducers/__tests__/adminResourcesPageReducer.spec.js
@@ -11,7 +11,7 @@ describe('Reducer: adminResourcesPageReducer', () => {
   describe('initial state', () => {
     const initialState = adminResourcesPageReducer(undefined, {});
 
-    it('resourceIds should be an empty array', () => {
+    it('resourceIds is an empty array', () => {
       expect(initialState.resourceIds).to.deep.equal([]);
     });
   });

--- a/app/reducers/__tests__/authReducer.spec.js
+++ b/app/reducers/__tests__/authReducer.spec.js
@@ -10,11 +10,11 @@ describe('Reducer: authReducer', () => {
   describe('initial state', () => {
     const initialState = authReducer(undefined, {});
 
-    it('token should be null', () => {
+    it('token is null', () => {
       expect(initialState.token).to.equal(null);
     });
 
-    it('userId should be null', () => {
+    it('userId is null', () => {
       expect(initialState.userId).to.equal(null);
     });
   });
@@ -23,7 +23,7 @@ describe('Reducer: authReducer', () => {
     describe('API.RESERVATION_DELETE_ERROR', () => {
       const reservationDeleteError = createAction(types.API.RESERVATION_DELETE_ERROR);
 
-      it('should set state to initialState if error status is 401', () => {
+      it('sets state to initialState if error status is 401', () => {
         const action = reservationDeleteError({ status: 401 });
         const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
         const nextState = authReducer(initialState, action);
@@ -35,7 +35,7 @@ describe('Reducer: authReducer', () => {
         expect(nextState).to.deep.equal(expectedState);
       });
 
-      it('should not affect state if error status is not 401', () => {
+      it('does not affect state if error status is not 401', () => {
         const action = reservationDeleteError({ status: 403 });
         const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
         const nextState = authReducer(initialState, action);
@@ -48,7 +48,7 @@ describe('Reducer: authReducer', () => {
     describe('API.RESERVATION_POST_ERROR', () => {
       const reservationPostError = createAction(types.API.RESERVATION_POST_ERROR);
 
-      it('should set state to initialState if error status is 401', () => {
+      it('sets state to initialState if error status is 401', () => {
         const action = reservationPostError({ status: 401 });
         const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
         const nextState = authReducer(initialState, action);
@@ -60,7 +60,7 @@ describe('Reducer: authReducer', () => {
         expect(nextState).to.deep.equal(expectedState);
       });
 
-      it('should not affect state if error status is not 401', () => {
+      it('does not affect state if error status is not 401', () => {
         const action = reservationPostError({ status: 403 });
         const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
         const nextState = authReducer(initialState, action);
@@ -73,7 +73,7 @@ describe('Reducer: authReducer', () => {
     describe('API.RESERVATION_PUT_ERROR', () => {
       const reservationPutError = createAction(types.API.RESERVATION_PUT_ERROR);
 
-      it('should set state to initialState if error status is 401', () => {
+      it('sets state to initialState if error status is 401', () => {
         const action = reservationPutError({ status: 401 });
         const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
         const nextState = authReducer(initialState, action);
@@ -85,7 +85,7 @@ describe('Reducer: authReducer', () => {
         expect(nextState).to.deep.equal(expectedState);
       });
 
-      it('should not affect state if error status is not 401', () => {
+      it('does not affect state if error status is not 401', () => {
         const action = reservationPutError({ status: 403 });
         const initialState = Immutable({ token: 'mock-token', userId: 'u-1' });
         const nextState = authReducer(initialState, action);

--- a/app/reducers/__tests__/fetchCountsReducer.spec.js
+++ b/app/reducers/__tests__/fetchCountsReducer.spec.js
@@ -10,7 +10,7 @@ describe('Reducer: fetchCountsReducer', () => {
   describe('initial state', () => {
     const initialState = fetchCountsReducer(undefined, {});
 
-    it('reservations should be 0', () => {
+    it('reservations is 0', () => {
       expect(initialState.reservations).to.equal(0);
     });
   });
@@ -19,7 +19,7 @@ describe('Reducer: fetchCountsReducer', () => {
     describe('API.RESERVATIONS_GET_SUCCESS', () => {
       const getReservationsSuccess = createAction(types.API.RESERVATIONS_GET_SUCCESS);
 
-      it('should increase reservations by 1', () => {
+      it('increases reservations by 1', () => {
         const action = getReservationsSuccess();
         const initialState = Immutable({
           reservations: 3,

--- a/app/reducers/__tests__/modalsReducer.spec.js
+++ b/app/reducers/__tests__/modalsReducer.spec.js
@@ -10,7 +10,7 @@ describe('Reducer: modalsReducer', () => {
   describe('initial state', () => {
     const initialState = modalsReducer(undefined, {});
 
-    it('open should be an empty array', () => {
+    it('open is an empty array', () => {
       expect(initialState.open).to.deep.equal([]);
     });
   });
@@ -20,7 +20,7 @@ describe('Reducer: modalsReducer', () => {
       const closeModal = createAction(types.UI.CLOSE_MODAL);
 
       describe('if modal is open', () => {
-        it('should remove the given modal from open', () => {
+        it('removes the given modal from open', () => {
           const initialState = Immutable({ open: ['some-modal'] });
           const action = closeModal('some-modal');
           const nextState = modalsReducer(initialState, action);
@@ -29,7 +29,7 @@ describe('Reducer: modalsReducer', () => {
           expect(nextState).to.deep.equal(expected);
         });
 
-        it('should not affect other modals in open', () => {
+        it('does not affect other modals in open', () => {
           const initialState = Immutable({ open: ['other-modal', 'some-modal'] });
           const action = closeModal('some-modal');
           const nextState = modalsReducer(initialState, action);
@@ -40,7 +40,7 @@ describe('Reducer: modalsReducer', () => {
       });
 
       describe('if modal is not open', () => {
-        it('should not change open in any way', () => {
+        it('does not change open in any way', () => {
           const action = closeModal('some-modal');
           const initialState = Immutable({ open: ['other-modal'] });
           const nextState = modalsReducer(initialState, action);
@@ -54,7 +54,7 @@ describe('Reducer: modalsReducer', () => {
       const openModal = createAction(types.UI.OPEN_MODAL);
 
       describe('if modal is not open', () => {
-        it('should add the given modal to open', () => {
+        it('adds the given modal to open', () => {
           const initialState = Immutable({ open: [] });
           const action = openModal('some-modal');
           const nextState = modalsReducer(initialState, action);
@@ -63,7 +63,7 @@ describe('Reducer: modalsReducer', () => {
           expect(nextState).to.deep.equal(expected);
         });
 
-        it('should not affect other modals in open', () => {
+        it('does not affect other modals in open', () => {
           const initialState = Immutable({ open: ['other-modal'] });
           const action = openModal('some-modal');
           const nextState = modalsReducer(initialState, action);
@@ -74,7 +74,7 @@ describe('Reducer: modalsReducer', () => {
       });
 
       describe('if modal is already open', () => {
-        it('should not change open in any way', () => {
+        it('does not change open in any way', () => {
           const action = openModal('some-modal');
           const initialState = Immutable({ open: ['other-modal', 'some-modal'] });
           const nextState = modalsReducer(initialState, action);

--- a/app/reducers/__tests__/reservationsReducer.spec.js
+++ b/app/reducers/__tests__/reservationsReducer.spec.js
@@ -25,28 +25,28 @@ describe('Reducer: reservationsReducer', () => {
     const initialState = reservationsReducer(undefined, {});
 
     describe('adminReservationFilters', () => {
-      it('should be an object', () => {
+      it('is an object', () => {
         expect(typeof initialState.adminReservationFilters).to.equal('object');
       });
 
-      it('state should be "all"', () => {
+      it('state is "all"', () => {
         expect(initialState.adminReservationFilters.state).to.equal('all');
       });
     });
 
-    it('selected should be an empty array', () => {
+    it('selected is an empty array', () => {
       expect(initialState.selected).to.deep.equal([]);
     });
 
-    it('toCancel should be an empty array', () => {
+    it('toCancel is an empty array', () => {
       expect(initialState.toCancel).to.deep.equal([]);
     });
 
-    it('toEdit should be an empty array', () => {
+    it('toEdit is an empty array', () => {
       expect(initialState.toEdit).to.deep.equal([]);
     });
 
-    it('toShow should be an empty array', () => {
+    it('toShow is an empty array', () => {
       expect(initialState.toShow).to.deep.equal([]);
     });
   });
@@ -55,7 +55,7 @@ describe('Reducer: reservationsReducer', () => {
     describe('API.RESERVATION_POST_SUCCESS', () => {
       const postReservationSuccess = createAction(types.API.RESERVATION_POST_SUCCESS);
 
-      it('should clear selected', () => {
+      it('clears selected', () => {
         const action = postReservationSuccess();
         const initialState = Immutable({
           selected: ['some-selected'],
@@ -66,7 +66,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.selected).to.deep.equal([]);
       });
 
-      it('should clear the toEdit', () => {
+      it('clears the toEdit', () => {
         const action = postReservationSuccess();
         const initialState = Immutable({
           toEdit: ['something-to-edit'],
@@ -77,7 +77,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.toEdit).to.deep.equal([]);
       });
 
-      it('should add the given reservation to toShow', () => {
+      it('adds the given reservation to toShow', () => {
         const initialState = Immutable({
           toShow: [],
         });
@@ -89,7 +89,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.toShow).to.deep.equal(expected);
       });
 
-      it('should not affect other reservations in toShow', () => {
+      it('does not affect other reservations in toShow', () => {
         const reservations = [
           Reservation.build(),
           Reservation.build(),
@@ -108,7 +108,7 @@ describe('Reducer: reservationsReducer', () => {
     describe('API.RESERVATION_PUT_SUCCESS', () => {
       const putReservationSuccess = createAction(types.API.RESERVATION_PUT_SUCCESS);
 
-      it('should clear selected', () => {
+      it('clears selected', () => {
         const action = putReservationSuccess();
         const initialState = Immutable({
           selected: ['some-selected'],
@@ -118,7 +118,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.selected).to.deep.equal([]);
       });
 
-      it('should clear the toEdit', () => {
+      it('clears the toEdit', () => {
         const action = putReservationSuccess();
         const initialState = Immutable({
           toEdit: ['something-to-edit'],
@@ -128,7 +128,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.toEdit).to.deep.equal([]);
       });
 
-      it('should clear the toShow', () => {
+      it('clears the toShow', () => {
         const action = putReservationSuccess();
         const initialState = Immutable({
           toShow: ['something-to-show'],
@@ -140,7 +140,7 @@ describe('Reducer: reservationsReducer', () => {
     });
 
     describe('UI.CANCEL_RESERVATION_EDIT', () => {
-      it('should clear toEdit array', () => {
+      it('clears toEdit array', () => {
         const initialState = Immutable({
           toEdit: [Reservation.build()],
         });
@@ -152,7 +152,7 @@ describe('Reducer: reservationsReducer', () => {
     });
 
     describe('UI.CHANGE_ADMIN_RESERVATIONS_FILTERS', () => {
-      it('should set the given filters to adminReservationFilters', () => {
+      it('sets the given filters to adminReservationFilters', () => {
         const adminReservationFilters = { state: 'some-state' };
         const action = changeAdminReservationFilters(adminReservationFilters);
         const initialState = Immutable({
@@ -164,7 +164,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.adminReservationFilters).to.deep.equal(expected);
       });
 
-      it('should override previous values of same adminReservationFilters', () => {
+      it('overrides previous values of same adminReservationFilters', () => {
         const adminReservationFilters = { state: 'some-state' };
         const action = changeAdminReservationFilters(adminReservationFilters);
         const initialState = Immutable({
@@ -176,7 +176,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.adminReservationFilters).to.deep.equal(expected);
       });
 
-      it('should not override unspecified adminReservationFilters', () => {
+      it('does not override unspecified adminReservationFilters', () => {
         const adminReservationFilters = { state: 'some-state' };
         const action = changeAdminReservationFilters(adminReservationFilters);
         const initialState = Immutable({
@@ -193,7 +193,7 @@ describe('Reducer: reservationsReducer', () => {
     });
 
     describe('UI.CLEAR_RESERVATIONS', () => {
-      it('should set the given date to date', () => {
+      it('sets the given date to date', () => {
         const resetedState = reservationsReducer(undefined, {});
         const action = clearReservations();
         const initialState = Immutable({
@@ -211,7 +211,7 @@ describe('Reducer: reservationsReducer', () => {
 
     describe('UI.CLOSE_MODAL', () => {
       describe('if closed modal is RESERVATION_CANCEL modal', () => {
-        it('should clear toCancel array', () => {
+        it('clears toCancel array', () => {
           const initialState = Immutable({
             toCancel: [Reservation.build()],
           });
@@ -223,7 +223,7 @@ describe('Reducer: reservationsReducer', () => {
       });
 
       describe('if closed modal is RESERVATION_COMMENT modal', () => {
-        it('should clear toShow array', () => {
+        it('clears toShow array', () => {
           const initialState = Immutable({
             toShow: [Reservation.build()],
           });
@@ -235,7 +235,7 @@ describe('Reducer: reservationsReducer', () => {
       });
 
       describe('if closed modal is RESERVATION_INFO modal', () => {
-        it('should clear toShow array', () => {
+        it('clears toShow array', () => {
           const initialState = Immutable({
             toShow: [Reservation.build()],
           });
@@ -247,7 +247,7 @@ describe('Reducer: reservationsReducer', () => {
       });
 
       describe('if closed modal is RESERVATION_SUCCESS modal', () => {
-        it('should clear toShow array', () => {
+        it('clears toShow array', () => {
           const initialState = Immutable({
             toShow: [Reservation.build()],
           });
@@ -260,7 +260,7 @@ describe('Reducer: reservationsReducer', () => {
     });
 
     describe('UI.SELECT_RESERVATION_TO_CANCEL', () => {
-      it('should add the given reservation to toCancel', () => {
+      it('adds the given reservation to toCancel', () => {
         const initialState = Immutable({
           toCancel: [],
         });
@@ -272,7 +272,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.toCancel).to.deep.equal(expected);
       });
 
-      it('should not affect other reservations in toCancel', () => {
+      it('does not affect other reservations in toCancel', () => {
         const reservations = [
           Reservation.build(),
           Reservation.build(),
@@ -289,7 +289,7 @@ describe('Reducer: reservationsReducer', () => {
     });
 
     describe('UI.SELECT_RESERVATION_TO_EDIT', () => {
-      it('should set the given reservation to toEdit', () => {
+      it('sets the given reservation to toEdit', () => {
         const initialState = Immutable({
           selected: [],
           toEdit: [],
@@ -302,7 +302,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.toEdit).to.deep.equal(expected);
       });
 
-      it('should remove other reservations in toEdit', () => {
+      it('removes other reservations in toEdit', () => {
         const reservations = [
           Reservation.build(),
           Reservation.build(),
@@ -318,7 +318,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.toEdit).to.deep.equal(expected);
       });
 
-      it('should split the given reservation to slots and add to selected', () => {
+      it('splits the given reservation to slots and add to selected', () => {
         const begin = '2015-10-09T08:00:00+03:00';
         const end = '2015-10-09T10:00:00+03:00';
         const minPeriod = '00:30:00';
@@ -337,7 +337,7 @@ describe('Reducer: reservationsReducer', () => {
     });
 
     describe('UI.SELECT_RESERVATION_TO_SHOW', () => {
-      it('should add the given reservation to toShow', () => {
+      it('adds the given reservation to toShow', () => {
         const initialState = Immutable({
           toShow: [],
         });
@@ -349,7 +349,7 @@ describe('Reducer: reservationsReducer', () => {
         expect(nextState.toShow).to.deep.equal(expected);
       });
 
-      it('should not affect other reservations in toShow', () => {
+      it('does not affect other reservations in toShow', () => {
         const reservations = [
           Reservation.build(),
           Reservation.build(),
@@ -367,7 +367,7 @@ describe('Reducer: reservationsReducer', () => {
 
     describe('UI.TOGGLE_TIME_SLOT', () => {
       describe('if slot is not already selected', () => {
-        it('should add the given slot to selected', () => {
+        it('adds the given slot to selected', () => {
           const initialState = Immutable({
             selected: [],
           });
@@ -379,7 +379,7 @@ describe('Reducer: reservationsReducer', () => {
           expect(nextState.selected).to.deep.equal(expected);
         });
 
-        it('should not affect other selected slots ', () => {
+        it('does not affect other selected slots ', () => {
           const initialState = Immutable({
             selected: ['2015-12-12T10:00:00Z/2015-12-12T11:00:00Z'],
           });
@@ -393,7 +393,7 @@ describe('Reducer: reservationsReducer', () => {
       });
 
       describe('if slot is already selected', () => {
-        it('should remove the given slot from selected', () => {
+        it('removes the given slot from selected', () => {
           const slot = '2015-10-11T10:00:00Z/2015-10-11T11:00:00Z';
           const action = toggleTimeSlot(slot);
           const initialState = Immutable({
@@ -405,7 +405,7 @@ describe('Reducer: reservationsReducer', () => {
           expect(nextState.selected).to.deep.equal(expected);
         });
 
-        it('should not affect other selected slots ', () => {
+        it('does not affect other selected slots ', () => {
           const slot = '2015-10-11T10:00:00Z/2015-10-11T11:00:00Z';
           const action = toggleTimeSlot(slot);
           const initialState = Immutable({

--- a/app/reducers/__tests__/searchReducer.spec.js
+++ b/app/reducers/__tests__/searchReducer.spec.js
@@ -15,36 +15,36 @@ describe('Reducer: searchReducer', () => {
     const initialState = searchReducer(undefined, {});
 
     describe('filters', () => {
-      it('should be an object', () => {
+      it('is an object', () => {
         expect(typeof initialState.filters).to.equal('object');
       });
 
-      it('date should be an empty string', () => {
+      it('date is an empty string', () => {
         expect(initialState.filters.date).to.equal('');
       });
 
-      it('people should be an empty string', () => {
+      it('people is an empty string', () => {
         expect(initialState.filters.purpose).to.equal('');
       });
 
-      it('purpose should be an empty string', () => {
+      it('purpose is an empty string', () => {
         expect(initialState.filters.purpose).to.equal('');
       });
 
-      it('search should be an empty string', () => {
+      it('search is an empty string', () => {
         expect(initialState.filters.search).to.equal('');
       });
     });
 
-    it('results should be an empty array', () => {
+    it('results is an empty array', () => {
       expect(initialState.results).to.deep.equal([]);
     });
 
-    it('searchDone should be false', () => {
+    it('searchDone is false', () => {
       expect(initialState.searchDone).to.equal(false);
     });
 
-    it('typeaheadSuggestions should be an empty array', () => {
+    it('typeaheadSuggestions is an empty array', () => {
       expect(initialState.typeaheadSuggestions).to.deep.equal([]);
     });
   });
@@ -64,7 +64,7 @@ describe('Reducer: searchReducer', () => {
         Resource.build(),
       ];
 
-      it('should set the given resource ids to results', () => {
+      it('sets the given resource ids to results', () => {
         const action = searchResourcesSuccess(resources);
         const initialState = Immutable({
           results: [],
@@ -75,7 +75,7 @@ describe('Reducer: searchReducer', () => {
         expect(nextState.results).to.deep.equal(expected);
       });
 
-      it('should replace the old ids in searchResults.ids', () => {
+      it('replaces the old ids in searchResults.ids', () => {
         const action = searchResourcesSuccess(resources);
         const initialState = Immutable({
           results: ['replace-this'],
@@ -86,7 +86,7 @@ describe('Reducer: searchReducer', () => {
         expect(nextState.results).to.deep.equal(expected);
       });
 
-      it('should set searchDone to true', () => {
+      it('sets searchDone to true', () => {
         const action = searchResourcesSuccess(resources);
         const initialState = Immutable({
           searchDone: false,
@@ -109,7 +109,7 @@ describe('Reducer: searchReducer', () => {
         Resource.build(),
       ];
 
-      it('should set the given resources to typeaheadSuggestions', () => {
+      it('sets the given resources to typeaheadSuggestions', () => {
         const action = typeaheadSuggestionsSuccess(resources);
         const initialState = Immutable({
           typeaheadSuggestions: [],
@@ -120,7 +120,7 @@ describe('Reducer: searchReducer', () => {
         expect(nextState.typeaheadSuggestions).to.deep.equal(expected);
       });
 
-      it('should replace the old ids in searchResults.ids', () => {
+      it('replaces the old ids in searchResults.ids', () => {
         const action = typeaheadSuggestionsSuccess(resources);
         const initialState = Immutable({
           typeaheadSuggestions: ['replace-this'],
@@ -135,7 +135,7 @@ describe('Reducer: searchReducer', () => {
     describe('UI.CHANGE_SEARCH_FILTERS', () => {
       const changeSearchFilters = createAction(types.UI.CHANGE_SEARCH_FILTERS);
 
-      it('should set the given filters to filters', () => {
+      it('sets the given filters to filters', () => {
         const filters = { purpose: 'some-purpose' };
         const action = changeSearchFilters(filters);
         const initialState = Immutable({
@@ -147,7 +147,7 @@ describe('Reducer: searchReducer', () => {
         expect(nextState.filters).to.deep.equal(expected);
       });
 
-      it('should override previous values of same filters', () => {
+      it('overrides previous values of same filters', () => {
         const filters = { purpose: 'some-purpose' };
         const action = changeSearchFilters(filters);
         const initialState = Immutable({
@@ -159,7 +159,7 @@ describe('Reducer: searchReducer', () => {
         expect(nextState.filters).to.deep.equal(expected);
       });
 
-      it('should not override unspecified filters', () => {
+      it('does not override unspecified filters', () => {
         const filters = { purpose: 'some-purpose' };
         const action = changeSearchFilters(filters);
         const initialState = Immutable({
@@ -174,7 +174,7 @@ describe('Reducer: searchReducer', () => {
         expect(nextState.filters).to.deep.equal(expected);
       });
 
-      it('should only save supported filters', () => {
+      it('saves only supported filters', () => {
         const filters = {
           purpose: 'some-purpose',
           search: 'search-query',
@@ -193,7 +193,7 @@ describe('Reducer: searchReducer', () => {
     });
 
     describe('UI.CLEAR_SEARCH_RESULTS', () => {
-      it('should empty the search results', () => {
+      it('empties the search results', () => {
         const action = clearSearchResults();
         const initialState = Immutable({
           results: ['r-1', 'r-2'],
@@ -203,7 +203,7 @@ describe('Reducer: searchReducer', () => {
         expect(nextState.results).to.deep.equal([]);
       });
 
-      it('should set searchDone to false', () => {
+      it('sets searchDone to false', () => {
         const action = clearSearchResults();
         const initialState = Immutable({
           searchDone: true,
@@ -213,7 +213,7 @@ describe('Reducer: searchReducer', () => {
         expect(nextState.searchDone).to.equal(false);
       });
 
-      it('should empty typeaheadSuggestions', () => {
+      it('empties typeaheadSuggestions', () => {
         const action = clearSearchResults();
         const initialState = Immutable({
           typeaheadSuggestions: ['r-1', 'r-2'],
@@ -225,7 +225,7 @@ describe('Reducer: searchReducer', () => {
     });
 
     describe('UPDATE_PATH', () => {
-      it('should parse filters from given path and set them to filters', () => {
+      it('parses filters from given path and set them to filters', () => {
         const path = 'search/?purpose=some-purpose';
         const action = { type: UPDATE_PATH, path };
         const initialState = Immutable({

--- a/app/reducers/__tests__/shouldFetchReducer.spec.js
+++ b/app/reducers/__tests__/shouldFetchReducer.spec.js
@@ -10,15 +10,15 @@ describe('Reducer: shouldFetchReducer', () => {
   describe('initial state', () => {
     const initialState = shouldFetchReducer(undefined, {});
 
-    it('purposes should be true', () => {
+    it('purposes is true', () => {
       expect(initialState.purposes).to.equal(true);
     });
 
-    it('resources should be true', () => {
+    it('resources is true', () => {
       expect(initialState.resources).to.equal(true);
     });
 
-    it('units should be true', () => {
+    it('units is true', () => {
       expect(initialState.units).to.equal(true);
     });
   });
@@ -27,7 +27,7 @@ describe('Reducer: shouldFetchReducer', () => {
     describe('API.PURPOSES_GET_SUCCESS', () => {
       const fetchPurposesSuccess = createAction(types.API.PURPOSES_GET_SUCCESS);
 
-      it('should set purposes to false', () => {
+      it('sets purposes to false', () => {
         const action = fetchPurposesSuccess();
         const initialState = Immutable({ purposes: true });
         const nextState = shouldFetchReducer(initialState, action);
@@ -39,7 +39,7 @@ describe('Reducer: shouldFetchReducer', () => {
     describe('API.RESOURCES_GET_SUCCESS', () => {
       const fetchResourcesSuccess = createAction(types.API.RESOURCES_GET_SUCCESS);
 
-      it('should set resources to false', () => {
+      it('sets resources to false', () => {
         const action = fetchResourcesSuccess();
         const initialState = Immutable({ resources: true });
         const nextState = shouldFetchReducer(initialState, action);
@@ -51,7 +51,7 @@ describe('Reducer: shouldFetchReducer', () => {
     describe('API.UNITS_GET_SUCCESS', () => {
       const fetchUnitsSuccess = createAction(types.API.UNITS_GET_SUCCESS);
 
-      it('should set units to false', () => {
+      it('sets units to false', () => {
         const action = fetchUnitsSuccess();
         const initialState = Immutable({ units: true });
         const nextState = shouldFetchReducer(initialState, action);

--- a/app/selectors/__tests__/currentUserSelector.spec.js
+++ b/app/selectors/__tests__/currentUserSelector.spec.js
@@ -21,7 +21,7 @@ function getState(users, loggedInUserId) {
 describe('Selector: currentUserSelector', () => {
   const users = [User.build()];
 
-  it('should return user corresponding to the auth.userId', () => {
+  it('returns user corresponding to the auth.userId', () => {
     const user = users[0];
     const state = getState(users, user.id);
     const selected = currentUserSelector(state);
@@ -29,14 +29,14 @@ describe('Selector: currentUserSelector', () => {
     expect(selected).to.deep.equal(user);
   });
 
-  it('should return an empty object if user with the given id does not exist', () => {
+  it('returns an empty object if user with the given id does not exist', () => {
     const state = getState(users, 'unknown-id');
     const selected = currentUserSelector(state);
 
     expect(selected).to.deep.equal({});
   });
 
-  it('should return an empty object if user is not logged in', () => {
+  it('returns an empty object if user is not logged in', () => {
     const state = getState(users, null);
     const selected = currentUserSelector(state);
 

--- a/app/selectors/__tests__/groupedPurposesSelector.spec.js
+++ b/app/selectors/__tests__/groupedPurposesSelector.spec.js
@@ -22,14 +22,14 @@ describe('Selector: groupedPurposesSelector', () => {
     Purpose.build({ parent: parents[0] }),
   ];
 
-  it('should return an empty object if there are no purposes in state', () => {
+  it('returns an empty object if there are no purposes in state', () => {
     const state = getState([]);
     const actual = groupedPurposesSelector(state);
 
     expect(actual).to.deep.equal({});
   });
 
-  it('should return purposes from the state grouped by parent', () => {
+  it('returns purposes from the state grouped by parent', () => {
     const state = getState(purposes);
     const actual = groupedPurposesSelector(state);
     const expected = Immutable({
@@ -40,7 +40,7 @@ describe('Selector: groupedPurposesSelector', () => {
     expect(actual).to.deep.equal(expected);
   });
 
-  it('should filter out purposes without a parent', () => {
+  it('filters out purposes without a parent', () => {
     const purposesWithoutParent = [
       Purpose.build({ parent: null }),
       Purpose.build({ parent: null }),

--- a/app/selectors/__tests__/isAdminSelector.spec.js
+++ b/app/selectors/__tests__/isAdminSelector.spec.js
@@ -18,14 +18,14 @@ function getState(user) {
 }
 
 describe('Selector: isAdminSelector', () => {
-  it('should return false if user is not logged in', () => {
+  it('returns false if user is not logged in', () => {
     const state = getInitialState();
     const actual = isAdminSelector(state);
 
     expect(actual).to.equal(false);
   });
 
-  it('should return false if user.isStaff is false', () => {
+  it('returns false if user.isStaff is false', () => {
     const user = User.build({ isStaff: false });
     const state = getState(user);
     const actual = isAdminSelector(state);
@@ -33,7 +33,7 @@ describe('Selector: isAdminSelector', () => {
     expect(actual).to.equal(false);
   });
 
-  it('should return true if user.isStaff is true', () => {
+  it('returns true if user.isStaff is true', () => {
     const user = User.build({ isStaff: true });
     const state = getState(user);
     const actual = isAdminSelector(state);

--- a/app/selectors/__tests__/isLoggedInSelector.spec.js
+++ b/app/selectors/__tests__/isLoggedInSelector.spec.js
@@ -12,21 +12,21 @@ function getState(token = null, userId = null) {
 }
 
 describe('Selector: isLoggedInSelector', () => {
-  it('should return false if token is null', () => {
+  it('returns false if token is null', () => {
     const state = getState(null, 'u-1');
     const actual = isLoggedInSelector(state);
 
     expect(actual).to.equal(false);
   });
 
-  it('should return false if userId is null', () => {
+  it('returns false if userId is null', () => {
     const state = getState('mock-token', null);
     const actual = isLoggedInSelector(state);
 
     expect(actual).to.equal(false);
   });
 
-  it('should return true if both token and userId are defined', () => {
+  it('returns true if both token and userId are defined', () => {
     const state = getState('mock-token', 'u-1');
     const actual = isLoggedInSelector(state);
 

--- a/app/selectors/__tests__/resourceSelector.spec.js
+++ b/app/selectors/__tests__/resourceSelector.spec.js
@@ -23,7 +23,7 @@ function getProps(id) {
 }
 
 describe('Selector: resourceSelector', () => {
-  it('should return the resource corresponding to the router.params.id', () => {
+  it('returns the resource corresponding to the router.params.id', () => {
     const resource = Resource.build();
     const state = getState([resource]);
     const props = getProps(resource.id);
@@ -32,7 +32,7 @@ describe('Selector: resourceSelector', () => {
     expect(actual).to.deep.equal(resource);
   });
 
-  it('should return an empty object as resource if resource with given id is not fetched', () => {
+  it('returns an empty object as resource if resource with given id is not fetched', () => {
     const state = getState([]);
     const props = getProps('unfetched-id');
     const actual = resourceSelector(state, props);

--- a/app/selectors/__tests__/selectedReservationsSelector.spec.js
+++ b/app/selectors/__tests__/selectedReservationsSelector.spec.js
@@ -28,7 +28,7 @@ describe('Selector: selectedReservationsSelector', () => {
     '2015-12-12T13:00:00+03:00/2015-12-12T14:00:00+03:00',
   ];
 
-  it('should return an empty object if no reservations are selected', () => {
+  it('returns an empty object if no reservations are selected', () => {
     const state = getState([]);
     const props = getProps();
     const actual = selectedReservationsSelector(state, props);
@@ -36,7 +36,7 @@ describe('Selector: selectedReservationsSelector', () => {
     expect(actual).to.deep.equal([]);
   });
 
-  it('should return selectedReservations in correct form', () => {
+  it('returns selectedReservations in correct form', () => {
     const state = getState([selected[0]]);
     const props = getProps();
     const actual = selectedReservationsSelector(state, props);
@@ -51,7 +51,7 @@ describe('Selector: selectedReservationsSelector', () => {
     expect(actual).to.deep.equal(expected);
   });
 
-  it('should combine reservations that if they are continual', () => {
+  it('combines reservations that if they are continual', () => {
     const state = getState(selected);
     const props = getProps();
     const actual = selectedReservationsSelector(state, props);

--- a/app/selectors/__tests__/staffUnitsSelector.spec.js
+++ b/app/selectors/__tests__/staffUnitsSelector.spec.js
@@ -18,7 +18,7 @@ function getState(user) {
 }
 
 describe('Selector: staffUnitsSelector', () => {
-  it('should return unit ids where user has can_approve_reservation permission', () => {
+  it('returns unit ids where user has can_approve_reservation permission', () => {
     const user = User.build({
       staffPerms: {
         unit: {
@@ -35,7 +35,7 @@ describe('Selector: staffUnitsSelector', () => {
   });
 
   it(
-    'should not return unit ids where user does not have can_approve_reservation permission',
+    'does not return unit ids where user does not have can_approve_reservation permission',
     () => {
       const user = User.build({
         staffPerms: {
@@ -54,7 +54,7 @@ describe('Selector: staffUnitsSelector', () => {
     }
   );
 
-  it('should return an empty array if user has no staff permissions', () => {
+  it('returns an empty array if user has no staff permissions', () => {
     const user = User.build();
     const state = getState(user);
     const selected = staffUnitsSelector(state);
@@ -62,7 +62,7 @@ describe('Selector: staffUnitsSelector', () => {
     expect(selected).to.deep.equal([]);
   });
 
-  it('should return an empty array if user has no staff permissions for units', () => {
+  it('returns an empty array if user has no staff permissions for units', () => {
     const user = User.build({
       staffPerms: {
         unit: {},

--- a/app/selectors/__tests__/timeSelector.spec.js
+++ b/app/selectors/__tests__/timeSelector.spec.js
@@ -13,7 +13,7 @@ function getProps(time) {
 }
 
 describe('Selector: timeSelector', () => {
-  it('should return the time ISOString in utc time if time is defined', () => {
+  it('returns the time ISOString in utc time if time is defined', () => {
     const time = '2015-11-12T09:00:00+02:00';
     const expected = '2015-11-12T07:00:00.000Z';
     const state = {};
@@ -23,7 +23,7 @@ describe('Selector: timeSelector', () => {
     expect(actual).to.equal(expected);
   });
 
-  it('should return undefined if time is not defined', () => {
+  it('returns undefined if time is not defined', () => {
     const state = {};
     const props = getProps();
     const actual = timeSelector(state, props);

--- a/app/selectors/__tests__/typeaheadOptionsSelector.spec.js
+++ b/app/selectors/__tests__/typeaheadOptionsSelector.spec.js
@@ -29,14 +29,14 @@ describe('Selector: typeaheadOptionsSelector', () => {
     Resource.build(),
   ];
 
-  it('should return an empty array if state contains no suggestions', () => {
+  it('returns an empty array if state contains no suggestions', () => {
     const state = getState([]);
     const actual = typeaheadOptionsSelector(state);
 
     expect(actual).to.deep.equal([]);
   });
 
-  it('should return an option object for each typeaheadSuggestion in state', () => {
+  it('returns an option object for each typeaheadSuggestion in state', () => {
     const state = getState(suggestions);
     const actual = typeaheadOptionsSelector(state);
 
@@ -48,21 +48,21 @@ describe('Selector: typeaheadOptionsSelector', () => {
     const state = getState([suggestion]);
     const option = typeaheadOptionsSelector(state)[0];
 
-    it('should have suggestion.id as its id property', () => {
+    it('has suggestion.id as its id property', () => {
       expect(option.id).to.equal(suggestion.id);
     });
 
-    it('should have suggestion.name.fi as its name property', () => {
+    it('has suggestion.name.fi as its name property', () => {
       expect(option.name).to.equal(suggestion.name.fi);
     });
 
-    it('should have unit.name.fi as its unitName property', () => {
+    it('has unit.name.fi as its unitName property', () => {
       const unit = state.data.units[suggestion.unit];
       expect(option.unitName).to.equal(unit.name.fi);
     });
   });
 
-  it('should work for multiple suggestions', () => {
+  it('works for multiple suggestions', () => {
     const state = getState(suggestions);
     const actual = typeaheadOptionsSelector(state);
     const expected = Immutable([

--- a/app/selectors/__tests__/uiSearchFiltersSelector.spec.js
+++ b/app/selectors/__tests__/uiSearchFiltersSelector.spec.js
@@ -19,7 +19,7 @@ function getState(date = '2015-10-10') {
 }
 
 describe('Selector: uiSearchFiltersSelector', () => {
-  it('should return search filters from the state', () => {
+  it('returns search filters from the state', () => {
     const state = getState();
     const actual = uiSearchFiltersSelector(state);
     const expected = state.ui.search.filters;
@@ -27,7 +27,7 @@ describe('Selector: uiSearchFiltersSelector', () => {
     expect(actual).to.deep.equal(expected);
   });
 
-  it('should return current date as the date filter if date is an empty string in state', () => {
+  it('returns current date as the date filter if date is an empty string in state', () => {
     const state = getState('');
     MockDate.set('2015-12-24T16:07:37Z');
     const actual = uiSearchFiltersSelector(state);

--- a/app/selectors/__tests__/urlSearchFiltersSelector.spec.js
+++ b/app/selectors/__tests__/urlSearchFiltersSelector.spec.js
@@ -17,7 +17,7 @@ function getProps(date = '2015-10-10') {
 }
 
 describe('Selector: urlSearchFiltersSelector', () => {
-  it('should return search filters from the props', () => {
+  it('returns search filters from the props', () => {
     const state = {};
     const props = getProps();
     const actual = urlSearchFiltersSelector(state, props);
@@ -26,7 +26,7 @@ describe('Selector: urlSearchFiltersSelector', () => {
     expect(actual).to.deep.equal(expected);
   });
 
-  it('should return current date as the date filter if date is an empty string in props', () => {
+  it('returns current date as the date filter if date is an empty string in props', () => {
     const state = {};
     const props = getProps('');
     MockDate.set('2015-12-24T16:07:37Z');

--- a/app/selectors/factories/__tests__/modalIsOpenSelectorFactory.spec.js
+++ b/app/selectors/factories/__tests__/modalIsOpenSelectorFactory.spec.js
@@ -15,21 +15,21 @@ function getState(openModals) {
 }
 
 describe('Selector factory: modalIsOpenSelectorFactory', () => {
-  it('should return a function', () => {
+  it('returns a function', () => {
     expect(typeof modalIsOpenSelectorFactory()).to.equal('function');
   });
 
   describe('the returned function', () => {
     const modalType = 'SOME_MODAL';
 
-    it('should return true if given modal is in open modals', () => {
+    it('returns true if given modal is in open modals', () => {
       const selector = modalIsOpenSelectorFactory(modalType);
       const state = getState([modalType]);
 
       expect(selector(state)).to.equal(true);
     });
 
-    it('should return false if given modal is not in open modals', () => {
+    it('returns false if given modal is not in open modals', () => {
       const selector = modalIsOpenSelectorFactory(modalType);
       const state = getState([]);
 

--- a/app/selectors/factories/__tests__/requestIsActiveSelectorFactory.spec.js
+++ b/app/selectors/factories/__tests__/requestIsActiveSelectorFactory.spec.js
@@ -13,28 +13,28 @@ function getState(activeRequests) {
 }
 
 describe('Selector factory: requestIsActiveSelectorFactory', () => {
-  it('should return a function', () => {
+  it('returns a function', () => {
     expect(typeof requestIsActiveSelectorFactory()).to.equal('function');
   });
 
   describe('the returned function', () => {
     const requestActionType = 'SOME_GET_REQUEST';
 
-    it('should return true if given request is in activeRequests with count > 0', () => {
+    it('returns true if given request is in activeRequests with count > 0', () => {
       const selector = requestIsActiveSelectorFactory(requestActionType);
       const state = getState({ [requestActionType]: 1 });
 
       expect(selector(state)).to.equal(true);
     });
 
-    it('should return false if given request is in activeRequests with count 0', () => {
+    it('returns false if given request is in activeRequests with count 0', () => {
       const selector = requestIsActiveSelectorFactory(requestActionType);
       const state = getState({ [requestActionType]: 0 });
 
       expect(selector(state)).to.equal(false);
     });
 
-    it('should return false if given request is not in activeRequests', () => {
+    it('returns false if given request is not in activeRequests', () => {
       const selector = requestIsActiveSelectorFactory(requestActionType);
       const state = getState({});
 

--- a/app/shared/date-header/DateHeaderComponent.spec.js
+++ b/app/shared/date-header/DateHeaderComponent.spec.js
@@ -49,7 +49,7 @@ describe('shared/date-header/DateHeaderComponent', () => {
           expect(button.length).to.equal(1);
         });
 
-        it('clicking the button should call onDecreaseDateButtonClick', () => {
+        it('clicking the button calls onDecreaseDateButtonClick', () => {
           extraProps.onDecreaseDateButtonClick.reset();
           button.props().onClick();
 
@@ -88,7 +88,7 @@ describe('shared/date-header/DateHeaderComponent', () => {
           expect(button.length).to.equal(1);
         });
 
-        it('clicking the button should call onIncreaseDateButtonClick', () => {
+        it('clicking the button calls onIncreaseDateButtonClick', () => {
           extraProps.onIncreaseDateButtonClick.reset();
           button.props().onClick();
 

--- a/app/shared/modals/reservation-success/ReservationSuccessModalContainer.spec.js
+++ b/app/shared/modals/reservation-success/ReservationSuccessModalContainer.spec.js
@@ -34,7 +34,7 @@ describe('shared/modals/reservation-success/ReservationSuccessModalContainer', (
   describe('render', () => {
     const wrapper = getWrapper();
 
-    it('should render a Modal component', () => {
+    it('renders a Modal component', () => {
       const modalComponent = wrapper.find(Modal);
 
       expect(modalComponent.length).to.equal(1);
@@ -43,21 +43,21 @@ describe('shared/modals/reservation-success/ReservationSuccessModalContainer', (
     describe('Modal header', () => {
       const modalHeader = wrapper.find(Modal.Header);
 
-      it('should render a ModalHeader component', () => {
+      it('renders a ModalHeader component', () => {
         expect(modalHeader.length).to.equal(1);
       });
 
-      it('should contain a close button', () => {
+      it('contains a close button', () => {
         expect(modalHeader.props().closeButton).to.equal(true);
       });
 
-      it('should render a ModalTitle component', () => {
+      it('renders a ModalTitle component', () => {
         const modalTitle = wrapper.find(Modal.Title);
 
         expect(modalTitle.length).to.equal(1);
       });
 
-      it('the ModalTitle should display text "Varauspyyntösi on lähetetty"', () => {
+      it('the ModalTitle displays text "Varauspyyntösi on lähetetty"', () => {
         const modalTitle = wrapper.find(Modal.Title);
 
         expect(modalTitle.props().children).to.equal('Varauspyyntösi on lähetetty');
@@ -67,17 +67,17 @@ describe('shared/modals/reservation-success/ReservationSuccessModalContainer', (
     describe('Modal body', () => {
       const modalBody = wrapper.find(Modal.Body);
 
-      it('should render a ModalBody component', () => {
+      it('renders a ModalBody component', () => {
         expect(modalBody.length).to.equal(1);
       });
 
       describe('reservation list', () => {
-        it('should render a CompactReservationList component', () => {
+        it('renders a CompactReservationList component', () => {
           const list = modalBody.find(CompactReservationList);
           expect(list.length).to.equal(1);
         });
 
-        it('should pass correct props to CompactReservationList component', () => {
+        it('passes correct props to CompactReservationList component', () => {
           const list = modalBody.find(CompactReservationList);
           expect(list.props().reservations).to.deep.equal(defaultProps.reservationsToShow);
           expect(list.props().resources).to.equal(undefined);
@@ -88,25 +88,25 @@ describe('shared/modals/reservation-success/ReservationSuccessModalContainer', (
     describe('Modal footer', () => {
       const modalFooter = wrapper.find(Modal.Footer);
 
-      it('should render a ModalFooter component', () => {
+      it('renders a ModalFooter component', () => {
         expect(modalFooter.length).to.equal(1);
       });
 
       describe('Footer buttons', () => {
         const buttons = modalFooter.find(Button);
 
-        it('should render one Button', () => {
+        it('renders one Button', () => {
           expect(buttons.length).to.equal(1);
         });
 
         describe('the button', () => {
           const button = buttons.at(0);
 
-          it('should read "Takaisin"', () => {
+          it('has text "Takaisin"', () => {
             expect(button.props().children).to.equal('Takaisin');
           });
 
-          it('clicking it should call closeReservationSuccessModal', () => {
+          it('clicking it calls closeReservationSuccessModal', () => {
             defaultProps.actions.closeReservationSuccessModal.reset();
             button.props().onClick();
 

--- a/app/shared/resource-list/ResourceList.spec.js
+++ b/app/shared/resource-list/ResourceList.spec.js
@@ -40,11 +40,11 @@ describe('shared/resource-list/ResourceList', () => {
         resourceListItems = wrapper.find(ResourceListItem);
       });
 
-      it('should render a ResourceListItem for every resource in props', () => {
+      it('renders a ResourceListItem for every resource in props', () => {
         expect(resourceListItems.length).to.equal(defaultProps.resourceIds.length);
       });
 
-      it('should pass correct props to ResourceListItem', () => {
+      it('passes correct props to ResourceListItem', () => {
         resourceListItems.forEach((resourceListItem, index) => {
           expect(resourceListItem.props().resourceId).to.equal(defaultProps.resourceIds[index]);
         });

--- a/app/utils/__tests__/apiUtils.spec.js
+++ b/app/utils/__tests__/apiUtils.spec.js
@@ -18,20 +18,20 @@ describe('Utils: apiUtils', () => {
   describe('buildAPIUrl', () => {
     const endpoint = 'some/endpoint';
 
-    it('should return API_URL + given endpoint if params is empty', () => {
+    it('returns API_URL + given endpoint if params is empty', () => {
       const expected = `${constants.API_URL}/${endpoint}/`;
 
       expect(buildAPIUrl(endpoint)).to.equal(expected);
     });
 
-    it('should reject params with empty values', () => {
+    it('rejects params with empty values', () => {
       const params = { empty: '' };
       const expected = `${constants.API_URL}/${endpoint}/`;
 
       expect(buildAPIUrl(endpoint, params)).to.equal(expected);
     });
 
-    it('should append search params at the end if params is not empty', () => {
+    it('appends search params at the end if params is not empty', () => {
       const params = { param: 'hello_world' };
       const expected = `${constants.API_URL}/${endpoint}/?param=hello_world`;
 
@@ -40,12 +40,12 @@ describe('Utils: apiUtils', () => {
   });
 
   describe('createTransformFunction', () => {
-    it('should return a function', () => {
+    it('returns a function', () => {
       expect(typeof createTransformFunction()).to.equal('function');
     });
 
     describe('the returned function', () => {
-      it('should camelize object keys', () => {
+      it('camelizes object keys', () => {
         const transformFunction = createTransformFunction();
         const initial = {
           some_key: {
@@ -62,7 +62,7 @@ describe('Utils: apiUtils', () => {
       });
 
       describe('if normalizr Schema is provided', () => {
-        it('should use the Schema to normalize data', () => {
+        it('uses the Schema to normalize data', () => {
           const transformFunction = createTransformFunction(schemas.resourceSchema);
           const initialResourceData = {
             id: 'r-1',
@@ -91,17 +91,17 @@ describe('Utils: apiUtils', () => {
   describe('getErrorTypeDescriptor', () => {
     const actionType = 'SOME_GET_ERROR';
 
-    it('should return an object', () => {
+    it('returns an object', () => {
       expect(typeof getErrorTypeDescriptor(actionType)).to.equal('object');
     });
 
-    it('should contain the given action type', () => {
+    it('contains the given action type', () => {
       const actual = getErrorTypeDescriptor(actionType).type;
 
       expect(actual).to.equal(actionType);
     });
 
-    it('should contain a meta function', () => {
+    it('contains a meta function', () => {
       expect(typeof getErrorTypeDescriptor(actionType).meta).to.equal('function');
     });
 
@@ -112,7 +112,7 @@ describe('Utils: apiUtils', () => {
         },
       };
 
-      it('should return an object with correct properties', () => {
+      it('returns an object with correct properties', () => {
         const typeDescriptor = getErrorTypeDescriptor(actionType);
         const actual = typeDescriptor.meta(mockAction);
         const expected = {
@@ -126,7 +126,7 @@ describe('Utils: apiUtils', () => {
         expect(actual).to.deep.equal(expected);
       });
 
-      it('should support adding a countable property', () => {
+      it('supports adding a countable property', () => {
         const typeDescriptor = getErrorTypeDescriptor(actionType, { countable: true });
         const actual = typeDescriptor.meta(mockAction);
         const expected = {
@@ -143,7 +143,7 @@ describe('Utils: apiUtils', () => {
   });
 
   describe('getHeadersCreator', () => {
-    it('should return a function', () => {
+    it('returns a function', () => {
       expect(typeof getHeadersCreator()).to.equal('function');
     });
 
@@ -157,7 +157,7 @@ describe('Utils: apiUtils', () => {
         const authorizationHeader = { Authorization: 'JWT mock-token' };
 
         describe('if no additional headers are specified', () => {
-          it('should return the required headers and Authorization header', () => {
+          it('returns the required headers and Authorization header', () => {
             const creator = getHeadersCreator();
             const expected = Object.assign(
               {},
@@ -170,7 +170,7 @@ describe('Utils: apiUtils', () => {
         });
 
         describe('if additional headers are specified', () => {
-          it('should return the required, the additional and Authorization headers', () => {
+          it('returns the required, the additional and Authorization headers', () => {
             const additionalHeaders = {
               header: 'value',
             };
@@ -193,7 +193,7 @@ describe('Utils: apiUtils', () => {
         };
 
         describe('if no additional headers are specified', () => {
-          it('should return the just the required headers', () => {
+          it('returns the just the required headers', () => {
             const creator = getHeadersCreator();
 
             expect(creator(state)).to.deep.equal(constants.REQUIRED_API_HEADERS);
@@ -201,7 +201,7 @@ describe('Utils: apiUtils', () => {
         });
 
         describe('if additional headers are specified', () => {
-          it('should return the required headers and the additional headers', () => {
+          it('returns the required headers and the additional headers', () => {
             const additionalHeaders = {
               header: 'value',
             };
@@ -218,17 +218,17 @@ describe('Utils: apiUtils', () => {
   describe('getRequestTypeDescriptor', () => {
     const actionType = 'SOME_GET_REQUEST';
 
-    it('should return an object', () => {
+    it('returns an object', () => {
       expect(typeof getRequestTypeDescriptor(actionType)).to.equal('object');
     });
 
-    it('should contain the given action type', () => {
+    it('contains the given action type', () => {
       const actual = getRequestTypeDescriptor(actionType).type;
 
       expect(actual).to.equal(actionType);
     });
 
-    it('should contain a meta object with correct properties', () => {
+    it('contains a meta object with correct properties', () => {
       const actual = getRequestTypeDescriptor(actionType).meta;
       const expected = {
         API_ACTION: {
@@ -241,7 +241,7 @@ describe('Utils: apiUtils', () => {
       expect(actual).to.deep.equal(expected);
     });
 
-    it('should support adding coutable property to meta object', () => {
+    it('supports adding coutable property to meta object', () => {
       const actual = getRequestTypeDescriptor(actionType, { countable: true }).meta;
       const expected = {
         API_ACTION: {
@@ -254,7 +254,7 @@ describe('Utils: apiUtils', () => {
       expect(actual).to.deep.equal(expected);
     });
 
-    it('should support adding extra meta properties', () => {
+    it('supports adding extra meta properties', () => {
       const actual = getRequestTypeDescriptor(actionType, { meta: { test: 'test' } }).meta;
       const expected = {
         API_ACTION: {
@@ -270,28 +270,28 @@ describe('Utils: apiUtils', () => {
   });
 
   describe('getSearchParamsString', () => {
-    it('should return key and value of the param with "=" in between', () => {
+    it('returns key and value of the param with "=" in between', () => {
       const params = { param: 'hello' };
       const expected = 'param=hello';
 
       expect(getSearchParamsString(params)).to.equal(expected);
     });
 
-    it('should return multiple params separated with "&"', () => {
+    it('returns multiple params separated with "&"', () => {
       const params = { param: 'hello', other: 'world' };
       const expected = 'param=hello&other=world';
 
       expect(getSearchParamsString(params)).to.equal(expected);
     });
 
-    it('should use encodeURIComponent to both keys and values', () => {
+    it('uses encodeURIComponent to both keys and values', () => {
       const params = { päräm: 'hellö' };
       const expected = `${encodeURIComponent('päräm')}=${encodeURIComponent('hellö')}`;
 
       expect(getSearchParamsString(params)).to.equal(expected);
     });
 
-    it('should decamelize keys of the given params', () => {
+    it('decamelizes keys of the given params', () => {
       const params = { camelizedParam: 'hello' };
       const expected = 'camelized_param=hello';
 
@@ -302,21 +302,21 @@ describe('Utils: apiUtils', () => {
   describe('getSuccessTypeDescriptor', () => {
     const actionType = 'SOME_GET_SUCCESS';
 
-    it('should return an object', () => {
+    it('returns an object', () => {
       expect(typeof getSuccessTypeDescriptor(actionType)).to.equal('object');
     });
 
-    it('should contain the given action type', () => {
+    it('contains the given action type', () => {
       const actual = getSuccessTypeDescriptor(actionType).type;
 
       expect(actual).to.equal(actionType);
     });
 
-    it('should contain a payload function', () => {
+    it('contains a payload function', () => {
       expect(typeof getSuccessTypeDescriptor(actionType).payload).to.equal('function');
     });
 
-    it('should contain a meta function', () => {
+    it('contains a meta function', () => {
       expect(typeof getSuccessTypeDescriptor(actionType).meta).to.equal('function');
     });
 
@@ -327,7 +327,7 @@ describe('Utils: apiUtils', () => {
         },
       };
 
-      it('should return an object with correct properties', () => {
+      it('returns an object with correct properties', () => {
         const typeDescriptor = getSuccessTypeDescriptor(actionType);
         const actual = typeDescriptor.meta(mockAction);
         const expected = {
@@ -341,7 +341,7 @@ describe('Utils: apiUtils', () => {
         expect(actual).to.deep.equal(expected);
       });
 
-      it('should support adding a countable property', () => {
+      it('supports adding a countable property', () => {
         const typeDescriptor = getSuccessTypeDescriptor(actionType, { countable: true });
         const actual = typeDescriptor.meta(mockAction);
         const expected = {
@@ -355,13 +355,13 @@ describe('Utils: apiUtils', () => {
         expect(actual).to.deep.equal(expected);
       });
 
-      it('should support adding payload property', () => {
+      it('supports adding payload property', () => {
         const typeDescriptor = getSuccessTypeDescriptor(actionType, { payload: 'mock-payload' });
 
         expect(typeDescriptor.payload).to.equal('mock-payload');
       });
 
-      it('should support adding extra meta properties', () => {
+      it('supports adding extra meta properties', () => {
         const typeDescriptor = getSuccessTypeDescriptor(actionType, { meta: { test: 'test' } });
         const actual = typeDescriptor.meta(mockAction);
         const expected = {

--- a/app/utils/__tests__/customizationUtils.js
+++ b/app/utils/__tests__/customizationUtils.js
@@ -5,7 +5,7 @@ import { getCurrentCustomization } from 'utils/customizationUtils';
 describe('Utils: customizationUtils', () => {
   describe('getCurrentCustomization', () => {
     describe('when window.location.host does not match any customization', () => {
-      it('should return null', () => {
+      it('returns null', () => {
         expect(getCurrentCustomization()).to.equal(null);
       });
     });

--- a/app/utils/__tests__/reservationUtils.spec.js
+++ b/app/utils/__tests__/reservationUtils.spec.js
@@ -62,7 +62,7 @@ describe('Utils: reservationUtils', () => {
       expect(combine(reservations)).to.deep.equal(expected);
     });
 
-    it('should not combine two reservations if they are not continual', () => {
+    it('does not combine two reservations if they are not continual', () => {
       const reservations = [slots[0], slots[2]];
 
       expect(combine(reservations)).to.deep.equal(reservations);

--- a/app/utils/__tests__/timeUtils.spec.js
+++ b/app/utils/__tests__/timeUtils.spec.js
@@ -13,7 +13,7 @@ import {
 
 describe('Utils: timeUtils', () => {
   describe('addToDate', () => {
-    it('should add days to given date if daysToIncrement is positive', () => {
+    it('adds days to given date if daysToIncrement is positive', () => {
       const date = '2015-10-10';
       const actual = addToDate(date, 3);
       const expected = '2015-10-13';
@@ -21,7 +21,7 @@ describe('Utils: timeUtils', () => {
       expect(actual).to.equal(expected);
     });
 
-    it('should subtract days from given date if daysToIncrement is negative', () => {
+    it('subtracts days from given date if daysToIncrement is negative', () => {
       const date = '2015-10-10';
       const actual = addToDate(date, -3);
       const expected = '2015-10-07';
@@ -31,19 +31,19 @@ describe('Utils: timeUtils', () => {
   });
 
   describe('getDateStartAndEndTimes', () => {
-    it('should return an empty object if date is undefined', () => {
+    it('returns an empty object if date is undefined', () => {
       const date = undefined;
 
       expect(getDateStartAndEndTimes(date)).to.deep.equal({});
     });
 
-    it('should return an empty object if date is an empty string', () => {
+    it('returns an empty object if date is an empty string', () => {
       const date = '';
 
       expect(getDateStartAndEndTimes(date)).to.deep.equal({});
     });
 
-    it('should return an object with start and end properties', () => {
+    it('returns an object with start and end properties', () => {
       const date = '2015-10-10';
       const actual = getDateStartAndEndTimes(date);
 
@@ -51,7 +51,7 @@ describe('Utils: timeUtils', () => {
       expect(actual.end).to.exist;
     });
 
-    it('returned start and end times should be in correct form ', () => {
+    it('returned start and end times are in correct form ', () => {
       const date = '2015-10-10';
       const actual = getDateStartAndEndTimes(date);
 
@@ -61,21 +61,21 @@ describe('Utils: timeUtils', () => {
   });
 
   describe('getDateString', () => {
-    it('should return current date string if date is undefined', () => {
+    it('returns current date string if date is undefined', () => {
       const date = undefined;
       const expected = moment().format(constants.DATE_FORMAT);
 
       expect(getDateString(date)).to.equal(expected);
     });
 
-    it('should return current date string if date is an empty string', () => {
+    it('returns current date string if date is an empty string', () => {
       const date = '';
       const expected = moment().format(constants.DATE_FORMAT);
 
       expect(getDateString(date)).to.equal(expected);
     });
 
-    it('should return the date unchanged', () => {
+    it('returns the date unchanged', () => {
       const date = '2015-10-11';
 
       expect(getDateString(date)).to.equal(date);
@@ -88,25 +88,25 @@ describe('Utils: timeUtils', () => {
       const end = '2015-10-09T10:00:00+03:00';
       const period = '00:30:00';
 
-      it('should return an empty array if start is missing', () => {
+      it('returns an empty array if start is missing', () => {
         const actual = getTimeSlots(undefined, end, period);
 
         expect(actual).to.deep.equal([]);
       });
 
-      it('should return an empty array if end is missing', () => {
+      it('returns an empty array if end is missing', () => {
         const actual = getTimeSlots(start, undefined, period);
 
         expect(actual).to.deep.equal([]);
       });
 
-      it('should use 30 minutes as default duration if period is missing', () => {
+      it('uses 30 minutes as default duration if period is missing', () => {
         const actual = getTimeSlots(start, end, undefined);
 
         expect(actual.length).to.equal(4);
       });
 
-      it('should use empty array as default reservations if no reservations is given', () => {
+      it('uses empty array as default reservations if no reservations is given', () => {
         const timeSlots = getTimeSlots(start, end, period);
 
         timeSlots.forEach(timeSlot => {
@@ -122,40 +122,40 @@ describe('Utils: timeUtils', () => {
       const duration = moment.duration(period);
       const slots = getTimeSlots(start, end, period);
 
-      it('should return an array of length 4', () => {
+      it('returns an array of length 4', () => {
         expect(slots.length).to.equal(4);
       });
 
       describe('slot start and end times', () => {
-        it('returned slots should contain start and end properties', () => {
+        it('returned slots contains start and end properties', () => {
           expect(slots[0].start).to.exist;
           expect(slots[0].end).to.exist;
         });
 
-        it('start and end times should be in UTC', () => {
+        it('start and end times are in UTC', () => {
           expect(slots[0].start.endsWith('Z')).to.equal(true);
           expect(slots[0].end.endsWith('Z')).to.equal(true);
         });
 
-        it('the first time slot should start when the time range starts', () => {
+        it('the first time slot starts when the time range starts', () => {
           const expected = moment.utc(start).toISOString();
 
           expect(slots[0].start).to.equal(expected);
         });
 
-        it('the first time slot should end 30 minutes after start', () => {
+        it('the first time slot ends 30 minutes after start', () => {
           const expected = moment.utc(start).add(duration).toISOString();
 
           expect(slots[0].end).to.equal(expected);
         });
 
-        it('the last time slot should start 30 minutes before the time range ends', () => {
+        it('the last time slot starts 30 minutes before the time range ends', () => {
           const expected = moment.utc(end).subtract(duration).toISOString();
 
           expect(slots[3].start).to.equal(expected);
         });
 
-        it('the last time slot should end 30 minutes after start', () => {
+        it('the last time slot ends 30 minutes after start', () => {
           const expected = moment.utc(end).toISOString();
 
           expect(slots[3].end).to.equal(expected);
@@ -163,11 +163,11 @@ describe('Utils: timeUtils', () => {
       });
 
       describe('slot asISOString property', () => {
-        it('returned slots should contain asISOString property', () => {
+        it('returned slots contains asISOString property', () => {
           expect(slots[0].asISOString).to.exist;
         });
 
-        it('should be proper ISO format range representation', () => {
+        it('is proper ISO format range representation', () => {
           const startUTC = moment.utc(start);
           const endUTC = moment.utc(startUTC).add(duration);
           const expected = `${startUTC.toISOString()}/${endUTC.toISOString()}`;
@@ -177,11 +177,11 @@ describe('Utils: timeUtils', () => {
       });
 
       describe('slot asString property', () => {
-        it('returned slots should contain asString property', () => {
+        it('returned slots contains asString property', () => {
           expect(slots[0].asString).to.exist;
         });
 
-        it('should show the slot time range in local time', () => {
+        it('shows the slot time range in local time', () => {
           const startLocal = moment(start);
           const endLocal = moment(startLocal).add(duration);
           const startString = startLocal.format(constants.TIME_FORMAT);
@@ -207,16 +207,16 @@ describe('Utils: timeUtils', () => {
         ];
         const slots = getTimeSlots(start, end, period, reservations);
 
-        it('slot should not be marked reserved if reservation starts when slot ends', () => {
+        it('slot is not marked reserved if reservation starts when slot ends', () => {
           expect(slots[0].reserved).to.equal(false);
         });
 
-        it('should mark all the slots that are during reservation as reserved', () => {
+        it('marks all the slots that are during reservation as reserved', () => {
           expect(slots[1].reserved).to.equal(true);
           expect(slots[2].reserved).to.equal(true);
         });
 
-        it('slot should not be marked reserved if slots starts when reservation ends', () => {
+        it('slot is not marked reserved if slots starts when reservation ends', () => {
           expect(slots[3].reserved).to.equal(false);
         });
       });
@@ -234,7 +234,7 @@ describe('Utils: timeUtils', () => {
         ];
         const slots = getTimeSlots(start, end, period, reservations);
 
-        it('should use all reservations to find reserved slots', () => {
+        it('uses all reservations to find reserved slots', () => {
           expect(slots[0].reserved).to.equal(false);
           expect(slots[1].reserved).to.equal(true);
           expect(slots[2].reserved).to.equal(false);
@@ -255,13 +255,13 @@ describe('Utils: timeUtils', () => {
       ];
       const slots = getTimeSlots(start, end, period, reservations);
 
-      it('only first slot should have reservationStarting property', () => {
+      it('only first slot has reservationStarting property', () => {
         expect(slots[0].reservationStarting).to.equal(true);
         expect(slots[1].reservationStarting).to.equal(false);
         expect(slots[2].reservationStarting).to.equal(false);
       });
 
-      it('only last slot should have reservationEnding property', () => {
+      it('only last slot has reservationEnding property', () => {
         expect(slots[0].reservationEnding).to.equal(false);
         expect(slots[1].reservationEnding).to.equal(false);
         expect(slots[2].reservationEnding).to.equal(true);
@@ -283,16 +283,16 @@ describe('Utils: timeUtils', () => {
         ];
         const slots = getTimeSlots(start, end, period, reservations, reservationsToEdit);
 
-        it('slot should not be marked as editing if reservation starts when slot ends', () => {
+        it('slot is not marked as editing if reservation starts when slot ends', () => {
           expect(slots[0].editing).to.equal(false);
         });
 
-        it('should mark all the slots that are during reservation as editing', () => {
+        it('marks all the slots that are during reservation as editing', () => {
           expect(slots[1].editing).to.equal(true);
           expect(slots[2].editing).to.equal(true);
         });
 
-        it('slot should not be marked editing if slots starts when reservation ends', () => {
+        it('slot is not marked editing if slots starts when reservation ends', () => {
           expect(slots[3].editing).to.equal(false);
         });
       });
@@ -310,7 +310,7 @@ describe('Utils: timeUtils', () => {
         ];
         const slots = getTimeSlots(start, end, period, reservations, reservationsToEdit);
 
-        it('should use all reservations to find slots that are edited', () => {
+        it('uses all reservations to find slots that are edited', () => {
           expect(slots[0].editing).to.equal(false);
           expect(slots[1].editing).to.equal(true);
           expect(slots[2].editing).to.equal(false);

--- a/app/utils/testUtils.js
+++ b/app/utils/testUtils.js
@@ -155,7 +155,7 @@ function createApiTest(options) {
               promise = payload({ type: actionTests.type }, {}, response);
             });
 
-            it('should exist', () => {
+            it('exists', () => {
               expect(payload).to.exist;
             });
 
@@ -208,11 +208,11 @@ function getState(extraState = {}) {
 }
 
 function makeButtonTests(button, name, expectedText, expectedOnClickFunction) {
-  it(`should be an ${name} button`, () => {
+  it(`is an ${name} button`, () => {
     expect(button.props().children).to.equal(expectedText);
   });
 
-  it('clicking the button should call correct onClick function', () => {
+  it('clicking the button calls correct onClick function', () => {
     expectedOnClickFunction.reset();
     button.props().onClick();
 


### PR DESCRIPTION
The word "should" does not add any information. Just makes the
descriptions longer. Rather have verbs in present form.